### PR TITLE
Bug in PHP strict standards mode

### DIFF
--- a/lib/Stack.php
+++ b/lib/Stack.php
@@ -36,7 +36,8 @@ function pushFor($offset, $callback)
 
 function top($property = null)
 {
-    $frame = reset(all());
+    $all = all();
+    $frame = reset($all);
     if ($property) {
         return isset($frame[$property]) ? $frame[$property] : null;
     }


### PR DESCRIPTION
Simple change to fix a warning that is thrown when PHP is run instrict standards mode.
