### PR TITLE
Make sure there actually are tags in the file about to be spliced.

### DIFF
--- a/lib/Preprocessor/Callbacks/Generic.php
+++ b/lib/Preprocessor/Callbacks/Generic.php
@@ -63,7 +63,8 @@ function injectFalseExpressionAtBeginnings($expression)
         if (empty($openingTags) && empty($openingTagsWithEcho)) {
             return;
         }
-        if (empty($openingTagsWithEcho) || reset($openingTags) < reset($openingTagsWithEcho)) {
+        if (!empty($openingTags) &&
+            (empty($openingTagsWithEcho) || reset($openingTags) < reset($openingTagsWithEcho))) {
             $pos = reset($openingTags);
             $namespaceKeyword = $s->findNext(T_NAMESPACE, $pos);
             if ($namespaceKeyword !== INF) {


### PR DESCRIPTION
Without this, a file with only the echoing tag type could get stuff spliced in the wrong place.
