### PR TITLE
apply scheduled patches only once

### DIFF
--- a/src/Interceptor.php
+++ b/src/Interceptor.php
@@ -96,6 +96,7 @@ function applyScheduledPatches()
         if (Utils\callbackTargetDefined($function)) {
             assertPatchable($function, false);
             patchMethod($function, $patch, $handle);
+            unset(State::$scheduledPatches[$offset]);
         }
     }
 }

--- a/tests/applyScheduledPatchesOnlyOnce.phpt
+++ b/tests/applyScheduledPatchesOnlyOnce.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Apply scheduled patches once
+
+--FILE--
+<?php
+
+error_reporting(E_ALL | E_STRICT);
+
+require __DIR__ . "/../Patchwork.php";
+
+$callNumber = 0;
+Patchwork\replace("NamedObject::getName", function () use (&$callNumber) {
+    $callNumber++;
+});
+
+require __DIR__ . "/includes/NamedObject.php";
+
+$obj= new NamedObject('');
+$obj->getName();
+
+assert($callNumber === 1, "\$callNumber was $callNumber");
+
+?>
+===DONE===
+
+--EXPECT--
+===DONE===

--- a/tests/applyScheduledPatchesOnlyOnce.phpt
+++ b/tests/applyScheduledPatchesOnlyOnce.phpt
@@ -13,7 +13,9 @@ Patchwork\replace("NamedObject::getName", function () use (&$callNumber) {
     $callNumber++;
 });
 
+require __DIR__ . "/includes/TestUtils.php";// just for many many injects triggered
 require __DIR__ . "/includes/NamedObject.php";
+require __DIR__ . "/includes/Generator.php";// just for many many injects triggered
 
 $obj= new NamedObject('');
 $obj->getName();


### PR DESCRIPTION
In our project we use zend autoloader, so it's not easy control then class will be loaded, before or after I replace it's method. I found that if class loaded after, sometimes my replacement function call multiply time per one original method call.

That look like it's right to unset State::$scheduledPatches after them applied, but I'm not sure.