### PR TITLE
Fix return values from patched functions on HHVM

### DIFF
--- a/src/Interceptor.php
+++ b/src/Interceptor.php
@@ -209,7 +209,9 @@ function patchOnHHVM($function, $patch, PatchHandle $handle)
             $calledClass = get_class($obj);
         }
         $frame = count(debug_backtrace(false)) - 1;
+        $result = null;
         $done = intercept($class, $calledClass, $method, $frame, $result, $args);
+        return $result;
     });
     $handle->addExpirationHandler(getHHVMExpirationHandler($function));
 }


### PR DESCRIPTION
```
$ php --version
HipHop VM 3.9.1 (rel)
Compiler: tags/HHVM-3.9.1-0-g0f72cfc2f0a01fdfeb72fbcfeb247b72998a66db
Repo schema: 6416960c150a4a4726fda74b659105ded8819d9c
```

When running our phpunit test suite on HHVM we noticed a bunch of failures and notices. A little digging proved that return values from functions patched with Patchwork were always `null`. 

Turns out the `$result` is not initialized and returned properly in the `fb_intercept` closure. This is what the patch addresses. 
