### PR TITLE
Correctly handle class instances

### DIFF
--- a/src/CallRerouting.php
+++ b/src/CallRerouting.php
@@ -57,12 +57,14 @@ function applyWildcard($wildcard, callable $target, Handle $handle = null)
     list($class, $method, $instance) = Utils\interpretCallable($wildcard);
     if (!empty($instance)) {
         foreach (get_class_methods($instance) as $item) {
-            if (Utils\matchWildcard($method, $item) && !$handle->hasTag($item)) {
-                connect([$instance, $method], $target, $handle);
+            if (!$handle->hasTag($item)) {
+                connect([$instance, $item], $target, $handle);
                 $handle->tag($item);
             }
         }
+        $wildcard = $method;
     }
+
     $callables = Utils\matchWildcard($wildcard, Utils\getUserDefinedCallables());
     foreach ($callables as $callable) {
         if (!inPreprocessedFile($callable) || $handle->hasTag($callable)) {

--- a/tests/wildcard-class-instance.phpt
+++ b/tests/wildcard-class-instance.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Wildcards: redefine([$instance, '*'], 'catchAll') etc.
+
+--FILE--
+<?php
+
+assert_options(ASSERT_ACTIVE, 1);
+assert_options(ASSERT_WARNING, 1);
+error_reporting(E_ALL | E_STRICT);
+
+require __DIR__ . '/../Patchwork.php';
+require __DIR__ . '/includes/Functions.php';
+
+require __DIR__ . '/includes/Inheritance.php';
+
+$bar = new BarObject;
+
+Patchwork\redefine([$bar, '*'], function() {
+    return 'Whammy!';
+});
+
+assert($bar->getBar() === 'Whammy!');
+assert($bar->getFoo() === 'Whammy!');
+
+?>
+===DONE===
+
+--EXPECT--
+===DONE===


### PR DESCRIPTION
Currently when trying to use an instance of a class, you get the following error
```
Fatal error: Uncaught TypeError: Argument 2 passed to Patchwork\Utils\matchWildcard() must be of the type array, string given
```

This fixes the error by passing the correct arguments to the functions