### PR TITLE
Fix call_user_func when calling parent constructor

### DIFF
--- a/src/CallRerouting.php
+++ b/src/CallRerouting.php
@@ -514,6 +514,11 @@ function connectDefaultInternals()
                         }
                         $class = $actualClass;
                     }
+                    # When calling a parent constructor, the reference to the object being
+                    # constructed needs to be extracted from the stack info
+                    if (is_null($instance) && $method === '__construct') {
+                        $instance = $caller['object'];
+                    }
                     try {
                         $reflection = new \ReflectionMethod($class, $method);
                         $reflection->setAccessible(true);

--- a/tests/constructor-with-parent-user-func.phpt
+++ b/tests/constructor-with-parent-user-func.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Compatibility with call_user_func calling parent constructor.
+
+--FILE--
+<?php
+
+assert_options(ASSERT_ACTIVE, 1);
+assert_options(ASSERT_WARNING, 1);
+error_reporting(E_ALL | E_STRICT);
+
+$_SERVER['PHP_SELF'] = __FILE__;
+
+require __DIR__ . "/../Patchwork.php";
+require __DIR__ . "/includes/ConstructorWithParentUserFunc.php";
+
+$instance = new BarObject();
+assert($instance->attribute === "Initialized");
+
+?>
+===DONE===
+
+--EXPECT--
+===DONE===

--- a/tests/includes/ConstructorWithParentUserFunc.php
+++ b/tests/includes/ConstructorWithParentUserFunc.php
@@ -1,0 +1,18 @@
+<?php
+
+class FooObject
+{
+    public $attribute;
+
+    function __construct() {
+        $this->attribute = "Initialized";
+    }
+}
+
+class BarObject extends FooObject
+{
+    function __construct() {
+        // This is actually something that happens.
+        call_user_func(['parent', '__construct']);
+    }
+}


### PR DESCRIPTION
## Description
This PR fixes invocations of call_user_func when calling the parent constructor. An example is included in the test.

```php
    function __construct() {
        call_user_func(['parent', '__construct']);
    }
```