### PR TITLE
Fix debug_backtrace argument type

### DIFF
--- a/src/CallRerouting.php
+++ b/src/CallRerouting.php
@@ -373,7 +373,7 @@ function connectOnHHVM($function, Handle $handle)
         } elseif (is_object($obj)) {
             $calledClass = get_class($obj);
         }
-        $frame = count(debug_backtrace(false)) - 1;
+        $frame = count(debug_backtrace(0)) - 1;
         $result = null;
         $done = dispatch($class, $calledClass, $method, $frame, $result, $args);
         return $result;

--- a/src/CodeManipulation/Actions/CallRerouting.php
+++ b/src/CodeManipulation/Actions/CallRerouting.php
@@ -17,7 +17,7 @@ const CALL_INTERCEPTION_CODE = '
     $__pwClass = (__CLASS__ && __FUNCTION__ !== $__pwClosureName) ? __CLASS__ : null;
     if (!empty(\Patchwork\CallRerouting\State::$routes[$__pwClass][__FUNCTION__])) {
         $__pwCalledClass = $__pwClass ? \get_called_class() : null;
-        $__pwFrame = \count(\debug_backtrace(false));
+        $__pwFrame = \count(\debug_backtrace(0));
         if (\Patchwork\CallRerouting\dispatch($__pwClass, $__pwCalledClass, __FUNCTION__, $__pwFrame, $__pwResult)) {
             return $__pwResult;
         }


### PR DESCRIPTION
When patching a function defined inside a file with `declare(strict_types=1);`, the following exception is thrown on the line with the opening brace of the function:

    TypeError: debug_backtrace() expects parameter 1 to be integer, boolean given

This pull request fixes the issue by changing the argument to the correct type. The type was changed from `bool` to `int` in PHP 5.3.6. This fix also works for older versions of PHP, since `declare(strict_types=1);` was introduced in PHP 7.