### PR TITLE
Make tests using patchwork running under PHP 7.3

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,64 @@
+---
+checks:
+    php:
+        code_rating: true
+        duplication: true
+filter:
+    excluded_paths:
+    - "tests/"
+    - "vendor/"
+coding_style:
+    php:
+        indentation:
+            general:
+                use_tabs: true
+        spaces:
+            around_operators:
+                concatenation: true
+                negation: true
+
+build:
+    cache:
+        directories:
+        - vendor/
+    nodes:
+
+        php-coding-standards:
+            environment:
+                php: 7.1
+            tests:
+                override:
+                - idle_timeout: 4800
+                  command: "phpcs-run ./"
+
+        phpunit:
+            environment:
+                php: 5.6
+            tests:
+                override:
+                - idle_timeout: 4800
+                  command: "./vendor/bin/phpunit --coverage-clover ./coverage.xml"
+                  coverage:
+                      file: coverage.xml
+                      format: php-clover
+
+        php70:
+            environment:
+                php: 7.0
+
+        php71:
+            environment:
+                php: 7.1
+
+        php72:
+            environment:
+                php: 7.2
+
+        php73:
+            environment:
+                php: 7.3
+
+    tests:
+        override:
+        - idle_timeout: 4800
+          command: "./vendor/bin/phpunit"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 script: phpunit tests
 php:
+  - 7.3
+  - 7.2
   - 7.1
   - 7.0
   - 5.6

--- a/src/Config.php
+++ b/src/Config.php
@@ -71,13 +71,16 @@ function setBlacklist($data, $root)
 
 function isListed($path, array $list)
 {
-    $path = rtrim($path, '\\/');
-    foreach ($list as $item) {
-        if (strpos($path, $item) === 0) {
-            return true;
-        }
-    }
-    return false;
+	$path = rtrim($path, '\\/');
+	foreach ($list as $item) {
+		if (!is_string($item)) {
+			$item = chr($item);
+		}
+		if (strpos($path, $item) === 0) {
+			return true;
+		}
+	}
+	return false;
 }
 
 function isBlacklisted($path)


### PR DESCRIPTION
Problem is caused by the following:

Warning: Uncaught strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior