### PR TITLE
gitattributes: update export-ignore list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 /tests              export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
-/.travis.yml        export-ignore
+/.scrutinizer.yml   export-ignore


### PR DESCRIPTION
* Don't export config files, like the scrutinizer file.
* Remove reference to `.travis.yml` file which no longer exists in the repo.