### PR TITLE
gitignore: prevent committing composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+composer.lock
 vendor/
 composer.phar
 .DS_Store


### PR DESCRIPTION
As this file is currently not committed and as this package is used as a library, it shouldn't be committed, let's prevent it from accidentally happening anyway.