### PR TITLE
PHP 8.1: fix "passing null to non-nullable" [1]

### DIFF
--- a/src/CallRerouting.php
+++ b/src/CallRerouting.php
@@ -138,7 +138,7 @@ function applyWildcard($wildcard, callable $target, Handle $handle = null)
         connect($callable, $target, $handle, true);
         $handle->tag($callable);
     }
-    if (!class_exists($class, false)) {
+    if (!isset($class) || !class_exists($class, false)) {
         queueConnection($wildcard, $target, $handle);
     }
     return $handle;


### PR DESCRIPTION
As of PHP 8.1, passing `null` to not explicitly nullable scalar parameters for PHP native functions is deprecated.

In this case, `$class` within `applyWildcard()` may be null, which leads to the following deprecation notice as can be seen when running the tests on PHP 8.1:
```
Deprecated: class_exists(): Passing null to parameter #1 ($class) of type string is deprecated in path/to/patchwork/src/CallRerouting.php on line 141
```

By handling `null` separately in the condition, the previous behaviour is maintained.

Refs:
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg
* https://www.php.net/manual/en/function.class-exists.php