### PR TITLE
PHP 8.1: fix "passing null to non-nullable" [2]

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -120,7 +120,7 @@ function interpretCallable($callback)
             $instance = $class;
             $class = get_class($class);
         }
-        $class = ltrim($class, "\\");
+        $class = isset($class) ? ltrim($class, "\\") : '';
         return [$class, $method, $instance];
     }
     if (substr($callback, 0, 4) === 'new ') {


### PR DESCRIPTION
As of PHP 8.1, passing `null` to not explicitly nullable scalar parameters for PHP native functions is deprecated.

In this case, `$class` within `interpretCallable()` may be null, which leads to the following deprecation notice as can be seen when running the tests on PHP 8.1:
```
Deprecated: ltrim(): Passing null to parameter #1 ($string) of type string is deprecated in path/to/patchwork/src/Utils.php on line 123
```

By handling `null` separately and setting `$class` to an empty string, the previous behaviour is maintained.

Refs:
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg
* https://www.php.net/manual/en/function.ltrim.php