### PR TITLE
PHP 8.1: fix implicit float conversion

### DIFF
--- a/src/CodeManipulation/Source.php
+++ b/src/CodeManipulation/Source.php
@@ -227,6 +227,7 @@ class Source
 
     function match($offset)
     {
+        $offset = (string) $offset;
         return isset($this->matchingBrackets[$offset]) ? $this->matchingBrackets[$offset] : INF;
     }
 


### PR DESCRIPTION
As of PHP 8.1, implicit conversion of a float value with a fractional part to integer, is deprecated.

In this case, `Source::match()` gets passed an offset, which _may_ not be an integer, while only strings and integers are allowed as array keys.
This means that PHP will automatically type juggle the float to an integer to be used for matching the array key.

As `$offset`, based on the above, theoretically can be either an integer or a string, making the conversion explicit by casting to integer may have the effect of destroying string keys.

Using a string cast is the more appropriate fix as integer keys passed as strings will then automatically be juggled to an integer by PHP anyway.

Fixes the following deprecation notice as can be seen when running the tests on PHP 8.1:
```
Deprecated: Implicit conversion from float INF to int loses precision in path/to/patchwork/src/CodeManipulation/Source.php on line 230
```

Refs:
* https://wiki.php.net/rfc/implicit-float-int-deprecate