### PR TITLE
PHP 8.1: fix tests for trait method replacement

### DIFF
--- a/tests/includes/TraitsWithAssertions.php
+++ b/tests/includes/TraitsWithAssertions.php
@@ -30,8 +30,12 @@ class Babbler
     }
 }
 
-assert(FooTrait::speak() === "spam");
-assert(BarTrait::speak() === "bar");
+# Direct calls to static trait methods are silencing a PHP 8.1 deprecation
+$foospeak = @FooTrait::speak();
+$barspeak = @BarTrait::speak();
+
+assert($foospeak === "spam");
+assert($barspeak === "bar");
 assert(Babbler::sayFoo() === "foo");
 assert(Babbler::sayBar() === "bacon");
 assert(Babbler::speak() === "eggs");

--- a/tests/traits.phpt
+++ b/tests/traits.phpt
@@ -12,8 +12,11 @@ require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Traits.php";
 
 # Initial behavior
-assert(FooTrait::speak() === "foo");
-assert(BarTrait::speak() === "bar");
+# Direct calls to static trait methods are silencing a PHP 8.1 deprecation
+$foospeak = @FooTrait::speak();
+$barspeak = @BarTrait::speak();
+assert($foospeak === "foo");
+assert($barspeak === "bar");
 assert(Babbler::sayFoo() === "foo");
 assert(Babbler::sayBar() === "bar");
 assert(Babbler::speak() === "foobar");
@@ -23,10 +26,12 @@ Patchwork\replace("BarTrait::speak", function() {
 });
 
 # Replacement #1
-assert(BarTrait::speak() === "spam");
+$barspeak = @BarTrait::speak();
+assert($barspeak === "spam");
 
 # No change expected
-assert(FooTrait::speak() === "foo");
+$foospeak = @FooTrait::speak();
+assert($foospeak === "foo");
 assert(Babbler::sayFoo() === "foo");
 assert(Babbler::sayBar() === "bar");
 assert(Babbler::speak() === "foobar");
@@ -39,10 +44,12 @@ Patchwork\replace("Babbler::speak", function() {
 assert(Babbler::speak() === "eggs");
 
 # Replacement #1
-assert(BarTrait::speak() === "spam");
+$barspeak = @BarTrait::speak();
+assert($barspeak === "spam");
 
 # No change expected
-assert(FooTrait::speak() === "foo");
+$foospeak = @FooTrait::speak();
+assert($foospeak === "foo");
 assert(Babbler::sayFoo() === "foo");
 assert(Babbler::sayBar() === "bar");
 
@@ -57,10 +64,12 @@ assert(Babbler::sayFoo() === "bacon");
 assert(Babbler::speak() === "eggs");
 
 # Replacement #1
-assert(BarTrait::speak() === "spam");
+$barspeak = @BarTrait::speak();
+assert($barspeak === "spam");
 
 # No change expected
-assert(FooTrait::speak() === "foo");
+$foospeak = @FooTrait::speak();
+assert($foospeak === "foo");
 assert(Babbler::sayBar() === "bar");
 
 ?>


### PR DESCRIPTION
Calling static trait members directly instead via a class using the trait is deprecated as of PHP 8.1.
The functionality will still work until PHP 9.0.

With that in mind, I'm only adjusting the tests to silence the deprecation notice from the direct calls to trait methods.
I've chosen to do so by moving the problematic calls to a separate statement and silencing the method call there. This prevent an failing assertion accidentally being silenced and the test not reporting correctly.

Fixes 2 tests/10 warnings along the lines of:
```
Deprecated: Calling static trait method FooTrait::speak is deprecated, it should only be called on a class using the trait
```

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_1#accessing_static_members_on_traits