### PR TITLE
GH Actions: fix tests not running on PHP 8.1 and other tweaks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: mbstring
+        ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
 
     # Install dependencies and handle caching in one go.
     # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,12 @@
 name: Tests
 on: [push, pull_request, workflow_dispatch]
 jobs:
-  run:
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        php-versions: 
+        php-versions:
         - '5.4'
         - '5.5'
         - '5.6'
@@ -17,6 +17,8 @@ jobs:
         - '7.4'
         - '8.0'
         - '8.1'
+    name: "PHP: ${{ matrix.php-versions }}"
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -27,6 +29,8 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         extensions: mbstring
         ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
+        coverage: none
+        tools: none
 
     # Install dependencies and handle caching in one go.
     # @link https://github.com/marketplace/actions/install-composer-dependencies
@@ -41,4 +45,4 @@ jobs:
         composer-options: --ignore-platform-reqs
 
     - name: Run tests
-      run: ./vendor/bin/phpunit tests
+      run: vendor/bin/phpunit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,12 +20,17 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: mbstring
-    - name: Install dependencies
-      run: composer install
+
+    # Install dependencies and handle caching in one go.
+    # @link https://github.com/marketplace/actions/install-composer-dependencies
+    - name: Install Composer dependencies
+      uses: "ramsey/composer-install@v1"
+
     - name: Run tests
       run: ./vendor/bin/phpunit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,15 @@ jobs:
 
     # Install dependencies and handle caching in one go.
     # @link https://github.com/marketplace/actions/install-composer-dependencies
-    - name: Install Composer dependencies
+    - name: "Install Composer dependencies (PHP < 8.1)"
+      if: ${{ matrix.php-versions < '8.1' }}
       uses: "ramsey/composer-install@v1"
+
+    - name: "Install Composer dependencies (PHP 8.1)"
+      if: ${{ matrix.php-versions >= '8.1' }}
+      uses: "ramsey/composer-install@v1"
+      with:
+        composer-options: --ignore-platform-reqs
 
     - name: Run tests
       run: ./vendor/bin/phpunit tests


### PR DESCRIPTION
### GH Actions: cache composer dependencies

... for lower network resource use and faster builds.

### GH Actions: fix tests not running on PHP 8.1

The tests weren't running on PHP 8.1 because PHPUnit 5.x was being installed as not all PHPUnit dependencies have declared PHP 8.1 compatibility yet.

Fixed by running `composer install` with the `--ignore-platform-requirements` option for now.

In the semi-near future, it should be possible to remove the special casing of PHP 8.1.

### GH Actions: set error reporting to -1

The default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `-1` and `display_errors=On` to ensure **all** PHP notices are shown.

Without this setting PHP 8.1 deprecation notices are not shown.

### GH Actions: minor other tweaks

* Make the name of the job more descriptive.
* Make the name of the individual builds more descriptive.
* Make it explicit that Xdebug nor PCOV should be installed by setup PHP as code coverage is not being recorded.
* Make it explicit that no PHP tooling is installed by setup PHP.


