### PR TITLE
GH Actions: ensure zend assertions is enabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: mbstring
-        ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
+        ini-values: zend.assertions=1, error_reporting=-1, display_errors=On, log_errors_max_len=0
         coverage: none
         tools: none
 


### PR DESCRIPTION
Similar to the change made in commit https://github.com/antecedent/patchwork/pull/111/commits/265791163faff4454c9811cde7cbaab9b4b104ca , `zend.assertions` is set to `-1` by default, so needs to be turned on by setting it to `1` for the tests to work.

This fixes the two errors previously identified in #112, ~~but exposes another test which really _does_ fail and that failure can be reproduced locally.~~ **Update: looks like that failure has been fixed in the mean time.**

Ref: https://github.com/shivammathur/setup-php/issues/450

Fixes #112