### PR TITLE
Handle PHP 8 attributes as opening brackets

### DIFF
--- a/src/CodeManipulation/Actions/Generic.php
+++ b/src/CodeManipulation/Actions/Generic.php
@@ -20,7 +20,7 @@ const LEFT_SQUARE = '[';
 const RIGHT_SQUARE = ']';
 const SEMICOLON = ';';
 
-foreach (['NAME_FULLY_QUALIFIED', 'NAME_QUALIFIED', 'NAME_RELATIVE', 'ELLIPSIS'] as $constant) {
+foreach (['NAME_FULLY_QUALIFIED', 'NAME_QUALIFIED', 'NAME_RELATIVE', 'ELLIPSIS', 'ATTRIBUTE'] as $constant) {
     if (defined('T_' . $constant)) {
         define(__NAMESPACE__ . '\\' . $constant, constant('T_' . $constant));
     } else {

--- a/src/CodeManipulation/Actions/RedefinitionOfLanguageConstructs.php
+++ b/src/CodeManipulation/Actions/RedefinitionOfLanguageConstructs.php
@@ -83,6 +83,7 @@ function getBracketTokens()
         Generic\LEFT_CURLY,
         T_CURLY_OPEN,
         T_DOLLAR_OPEN_CURLY_BRACES,
+        Generic\ATTRIBUTE,
     ];
 }
 

--- a/src/CodeManipulation/Actions/RedefinitionOfNew.php
+++ b/src/CodeManipulation/Actions/RedefinitionOfNew.php
@@ -108,6 +108,7 @@ function getBracketTokens()
         Generic\LEFT_CURLY,
         T_CURLY_OPEN,
         T_DOLLAR_OPEN_CURLY_BRACES,
+        Generic\ATTRIBUTE,
     ];
 }
 

--- a/src/CodeManipulation/Source.php
+++ b/src/CodeManipulation/Source.php
@@ -8,6 +8,7 @@
  */
 namespace Patchwork\CodeManipulation;
 
+use Patchwork\CodeManipulation\Actions\Generic;
 use Patchwork\Utils;
 
 class Source
@@ -73,6 +74,7 @@ class Source
                 case '{':
                 case T_CURLY_OPEN:
                 case T_DOLLAR_OPEN_CURLY_BRACES:
+                case Generic\ATTRIBUTE:
                     $stack[] = $offset;
                     break;
                 case ')':
@@ -102,6 +104,7 @@ class Source
                 case '{':
                 case T_CURLY_OPEN:
                 case T_DOLLAR_OPEN_CURLY_BRACES:
+                case Generic\ATTRIBUTE:
                     $level++;
                     Utils\appendUnder($this->levelBeginnings, $level, $offset);
                     break;

--- a/tests/includes/Php8Attributes.php
+++ b/tests/includes/Php8Attributes.php
@@ -1,0 +1,9 @@
+<?php
+
+class Foo
+{
+    #[\ReturnTypeWillChange]
+    public function bar()
+    {
+    }
+}

--- a/tests/php8-attributes.phpt
+++ b/tests/php8-attributes.phpt
@@ -1,0 +1,16 @@
+--TEST--
+https://github.com/antecedent/patchwork/issues/117
+
+--FILE--
+<?php
+
+error_reporting(E_ALL | E_STRICT);
+
+require __DIR__ . "/../Patchwork.php";
+require __DIR__ . "/includes/Php8Attributes.php";
+
+?>
+===DONE===
+
+--EXPECT--
+===DONE===


### PR DESCRIPTION
Under PHP 8 a `#[Attribute]` comes out as three tokens: `T_ATTRIBUTE`,
"Attribute", and "]". The logic for matching brackets needs to count
`T_ATTRIBUTE` as an open bracket so the "]" matches up properly.

Let's also add `T_ATTRIBUTE` to various other places where open-brackets
are listed.

Fixes #117