### PR TITLE
GH Actions: version update for `ramsey/composer-install`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,11 +36,11 @@ jobs:
     # @link https://github.com/marketplace/actions/install-composer-dependencies
     - name: "Install Composer dependencies (PHP < 8.1)"
       if: ${{ matrix.php-versions < '8.1' }}
-      uses: "ramsey/composer-install@v1"
+      uses: "ramsey/composer-install@v2"
 
     - name: "Install Composer dependencies (PHP 8.1)"
       if: ${{ matrix.php-versions >= '8.1' }}
-      uses: "ramsey/composer-install@v1"
+      uses: "ramsey/composer-install@v2"
       with:
         composer-options: --ignore-platform-reqs
 


### PR DESCRIPTION
The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Refs:
* https://github.com/ramsey/composer-install/releases/tag/2.0.0
* https://github.com/ramsey/composer-install/releases/tag/2.0.1
* https://github.com/ramsey/composer-install/releases/tag/2.0.2