### PR TITLE
Avoid parsing ini files from `parse_ini_file()`

### DIFF
--- a/src/CodeManipulation/Stream.php
+++ b/src/CodeManipulation/Stream.php
@@ -42,6 +42,15 @@ class Stream
     {
         $this->unwrap();
         $including = (bool) ($options & self::STREAM_OPEN_FOR_INCLUDE);
+
+        // In PHP 7 and 8, `parse_ini_file()` also sets STREAM_OPEN_FOR_INCLUDE.
+        if ($including) {
+            $frame = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1];
+            if (empty($frame['class']) && $frame['function'] === 'parse_ini_file') {
+                $including = false;
+            }
+        }
+
         if ($including && shouldTransform($path)) {
             $this->resource = transformAndOpen($path);
             $this->wrap();

--- a/tests/parse-ini-file.phpt
+++ b/tests/parse-ini-file.phpt
@@ -1,0 +1,26 @@
+--TEST--
+parse_ini_file isn't broken.
+
+--FILE--
+<?php
+
+require __DIR__ . "/../Patchwork.php";
+
+file_put_contents( __DIR__ . "/parse-ini-file.ini", <<<EOF
+; This is an ini file.
+; This comment has <?php and ?> in it.
+foo = bar
+EOF
+);
+
+$ini = parse_ini_file( __DIR__ . "/parse-ini-file.ini" );
+assert( $ini === array( "foo" => "bar" ) );
+?>
+===DONE===
+
+--CLEAN--
+<?php
+unlink( __DIR__ . "/parse-ini-file.ini" );
+?>
+--EXPECT--
+===DONE===


### PR DESCRIPTION
In PHP 7 and 8, `parse_ini_file()` calls the wrapper and sets
STREAM_OPEN_FOR_INCLUDE. None the less, we don't want to parse it.

It seems there's no direct way to differentiate such a call from a
`require` or `include` that we do need to process, other than by
checking the stack.

Fixes antecedent#124