### PR TITLE
Keep parenthesis around anonymous class parameters

### DIFF
--- a/src/CodeManipulation/Actions/RedefinitionOfNew.php
+++ b/src/CodeManipulation/Actions/RedefinitionOfNew.php
@@ -158,6 +158,7 @@ function hasExtraParentheses(Source $s, $new)
         T_ARRAY,
         T_PRINT,
         T_ECHO,
+        T_CLASS,
         Generic\NAME_FULLY_QUALIFIED,
         Generic\NAME_QUALIFIED,
         Generic\NAME_RELATIVE,

--- a/tests/includes/RedefinitionOfNewAsAnonymousClassParameter.php
+++ b/tests/includes/RedefinitionOfNewAsAnonymousClassParameter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Foo
+{
+    class TestClass
+    {
+    }
+}
+
+namespace Bar
+{
+    use Foo\TestClass;
+    use stdClass;
+
+    \Patchwork\redefine('new Foo\TestClass', \Patchwork\always(new stdClass));
+
+    $test = new class(new TestClass()) {
+        public $object;
+
+        public function __construct($object)
+        {
+            $this->object = $object;
+        }
+    };
+
+    assert($test->object instanceof stdClass);
+}

--- a/tests/redefine-new-anonymous-class-paramter.phpt
+++ b/tests/redefine-new-anonymous-class-paramter.phpt
@@ -1,0 +1,20 @@
+--TEST--
+https://github.com/antecedent/patchwork/issues/127
+
+--FILE--
+<?php
+
+assert_options(ASSERT_ACTIVE, 1);
+assert_options(ASSERT_WARNING, 1);
+error_reporting(E_ALL | E_STRICT);
+
+$_SERVER['PHP_SELF'] = __FILE__;
+
+require __DIR__ . "/../Patchwork.php";
+require __DIR__ . "/includes/RedefinitionOfNewAsAnonymousClassParameter.php";
+
+?>
+===DONE===
+
+--EXPECT--
+===DONE===


### PR DESCRIPTION
Fixes https://github.com/antecedent/patchwork/issues/127

This PR adds `T_CLASS` to `hasExtraParentheses()` so that id doesn't count parenthesis around anonymous class parameters as extra parenthesis.