### PR TITLE
GH Actions: fix test runs + start testing against PHP 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,10 @@ jobs:
         - '7.4'
         - '8.0'
         - '8.1'
+        - '8.2'
     name: "PHP: ${{ matrix.php-versions }}"
+
+    continue-on-error: ${{ matrix.php-versions == '8.2' }}
 
     steps:
     - name: Checkout
@@ -33,12 +36,12 @@ jobs:
 
     # Install dependencies and handle caching in one go.
     # @link https://github.com/marketplace/actions/install-composer-dependencies
-    - name: "Install Composer dependencies (PHP < 8.1)"
-      if: ${{ matrix.php-versions < '8.1' }}
+    - name: "Install Composer dependencies (PHP < 8.2)"
+      if: ${{ matrix.php-versions < '8.2' }}
       uses: "ramsey/composer-install@v2"
 
-    - name: "Install Composer dependencies (PHP 8.1)"
-      if: ${{ matrix.php-versions >= '8.1' }}
+    - name: "Install Composer dependencies (PHP 8.2)"
+      if: ${{ matrix.php-versions >= '8.2' }}
       uses: "ramsey/composer-install@v2"
       with:
         composer-options: --ignore-platform-reqs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,6 @@ jobs:
         extensions: mbstring
         ini-values: zend.assertions=1, error_reporting=-1, display_errors=On, log_errors_max_len=0
         coverage: none
-        tools: none
 
     # Install dependencies and handle caching in one go.
     # @link https://github.com/marketplace/actions/install-composer-dependencies


### PR DESCRIPTION
### GH Actions: fix test runs on PHP < 7.2

The `setup-php` action runner will automatically install the appropriate version of Composer depending on the PHP version requested - Composer 2.2 for PHP < 7.2 and Composer 2.3+ for PHP 7.2+.

However, using `tools: none` disables this and falls back to the Composer version which is shipped with the Ubuntu image being used.

Composer 2.3, which was released end of March, has a minimum PHP version of PHP 7.2, so will not work/be available to PHP < 7.2, so we need to ensure that the `setup-php` action runner installs the correct version, otherwise the `composer install` needed for the tests will fail.

Removing the `tools: none` should fix this.

**Note:**
Autoload files generated with Composer 2.3 are no longer compatible with PHP < 5.6, though Composer 2.2 (with a minimum PHP version of PHP 5.3) is now a LTS (long term service) release and will receive essential bug fixes.

As the humbug/box config is explicitly set up to not include a Composer generated autoload file, this should not impact the PHAR file which is generated on releases of this project.

If this would ever change, the release workflow would need to be adjusted to include `tools: composer:2.2` for the `setup-php` action runner.

Refs:
* https://blog.packagist.com/composer-2-3/
* https://github.com/composer/composer/releases
* https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md

### GH Actions: start running tests against PHP 8.2

PHP 8.2 - yet again - contains quite a number of deprecations which will become fatals in PHP 9.0.

As the impact is expected to be large, it is vital that packages used in the CI/test chain are ready in time to allow the applications/frameworks etc using these packages to get ready as well.

With that in mind, I'm proposing to start running the tests against PHP 8.2. At this time, the tests are passing, but keeping an eye on them over the next few months is strongly recommended.