### PR TITLE
Fix require of missing files

### DIFF
--- a/src/CodeManipulation.php
+++ b/src/CodeManipulation.php
@@ -118,8 +118,10 @@ function transformAndOpen($file)
     if (!internalToCache($file) && availableCached($file)) {
         return fopen(getCachedPath($file), 'r');
     }
-    $resource = fopen(OUTPUT_DESTINATION, OUTPUT_ACCESS_MODE);
     $code = file_get_contents($file, true);
+    if ($code === false) {
+        return false;
+    }
     $source = new Source($code);
     $source->file = $file;
     transform($source);
@@ -127,8 +129,11 @@ function transformAndOpen($file)
         storeInCache($source);
         return transformAndOpen($file);
     }
-    fwrite($resource, $source);
-    rewind($resource);
+    $resource = fopen(OUTPUT_DESTINATION, OUTPUT_ACCESS_MODE);
+    if ($resource) {
+        fwrite($resource, $source);
+        rewind($resource);
+    }
     return $resource;
 }
 

--- a/src/CodeManipulation/Stream.php
+++ b/src/CodeManipulation/Stream.php
@@ -54,7 +54,7 @@ class Stream
         if ($including && shouldTransform($path)) {
             $this->resource = transformAndOpen($path);
             $this->wrap();
-            return true;
+            return $this->resource !== false;
         }
         if (isset($this->context)) {
             $this->resource = fopen($path, $mode, $options, $this->context);

--- a/tests/require-missing-php5.phpt
+++ b/tests/require-missing-php5.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Include and require of nonexistent files
+
+--SKIPIF--
+<?php
+// PHP 8.0 changed require failing from a fatal error to a thrown exception. That's too much of a difference
+// to handle easily in EXPECTF, easier to just copy the file.
+version_compare(PHP_VERSION, "8.0", "<") or die("skip PHP 5 version of the test in PHP 8+");
+
+--FILE--
+<?php
+
+assert_options(ASSERT_ACTIVE, 1);
+assert_options(ASSERT_WARNING, 1);
+error_reporting(E_ALL | E_STRICT);
+
+require __DIR__ . "/../Patchwork.php";
+
+echo "Including missing file...\n";
+include __DIR__ . "/includes/does-not-exist.php";
+echo "Good, it did not throw/exit.\n\n";
+
+echo "Requiring missing file...\n";
+require __DIR__ . "/includes/does-not-exist.php";
+echo "It did not throw/exit. This is wrong.\n";
+
+?>
+===DONE===
+
+--EXPECTF--
+Including missing file...
+
+Warning: file_get_contents(%s/tests/includes/does-not-exist.php): failed to open stream: No such file or directory in %s/src/CodeManipulation.php on line %d
+
+Warning: include(%s/tests/includes/does-not-exist.php): failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in %s on line 10
+
+Warning: include(): Failed opening '%s/tests/includes/does-not-exist.php' for inclusion (include_path='%s') in %s on line 10
+Good, it did not throw/exit.
+
+Requiring missing file...
+
+Warning: file_get_contents(%s/tests/includes/does-not-exist.php): failed to open stream: No such file or directory in %s/src/CodeManipulation.php on line %d
+
+Warning: require(%s/tests/includes/does-not-exist.php): failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in %s on line 14
+
+Fatal error: require(): Failed opening required '%s/tests/includes/does-not-exist.php' (include_path='%s') in %s on line 14

--- a/tests/require-missing.phpt
+++ b/tests/require-missing.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Include and require of nonexistent files
+
+--SKIPIF--
+<?php
+// PHP 8.0 changed require failing from a fatal error to a thrown exception. That's too much of a difference
+// to handle easily in EXPECTF, easier to just copy the file.
+version_compare(PHP_VERSION, "8.0", ">=") or die("skip PHP 8+ version of the test in PHP <8");
+
+--FILE--
+<?php
+
+assert_options(ASSERT_ACTIVE, 1);
+assert_options(ASSERT_WARNING, 1);
+error_reporting(E_ALL | E_STRICT);
+
+require __DIR__ . "/../Patchwork.php";
+
+echo "Including missing file...\n";
+include __DIR__ . "/includes/does-not-exist.php";
+echo "Good, it did not throw/exit.\n\n";
+
+echo "Requiring missing file...\n";
+require __DIR__ . "/includes/does-not-exist.php";
+echo "It did not throw/exit. This is wrong.\n";
+
+?>
+===DONE===
+
+--EXPECTF--
+Including missing file...
+
+Warning: file_get_contents(%s/tests/includes/does-not-exist.php): Failed to open stream: No such file or directory in %s/src/CodeManipulation.php on line %d
+
+Warning: include(%s/tests/includes/does-not-exist.php): Failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in Standard input code on line 10
+
+Warning: include(): Failed opening '%s/tests/includes/does-not-exist.php' for inclusion (include_path='%s') in Standard input code on line 10
+Good, it did not throw/exit.
+
+Requiring missing file...
+
+Warning: file_get_contents(%s/tests/includes/does-not-exist.php): Failed to open stream: No such file or directory in %s/src/CodeManipulation.php on line %d
+
+Warning: require(%s/tests/includes/does-not-exist.php): Failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in Standard input code on line 14
+
+Fatal error: Uncaught Error: Failed opening required '%s/tests/includes/does-not-exist.php' (include_path='%s') in Standard input code:14
+Stack trace:
+#0 {main}
+  thrown in Standard input code on line 14


### PR DESCRIPTION
The stream wrapper was not checking for errors in reading the wrapped file, resulting in `require` treating it as an empty file instead of raising an error as it's supposed to.

This adds the needed error handling.