### PR TITLE
GH Actions: update PHP versions in workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,10 @@ jobs:
         - '8.0'
         - '8.1'
         - '8.2'
+        - '8.3'
     name: "PHP: ${{ matrix.php-versions }}"
 
-    continue-on-error: ${{ matrix.php-versions == '8.2' }}
+    continue-on-error: ${{ matrix.php-versions == '8.3' }}
 
     steps:
     - name: Checkout
@@ -36,12 +37,12 @@ jobs:
 
     # Install dependencies and handle caching in one go.
     # @link https://github.com/marketplace/actions/install-composer-dependencies
-    - name: "Install Composer dependencies (PHP < 8.2)"
-      if: ${{ matrix.php-versions < '8.2' }}
+    - name: "Install Composer dependencies (PHP < 8.3)"
+      if: ${{ matrix.php-versions < '8.3' }}
       uses: "ramsey/composer-install@v2"
 
-    - name: "Install Composer dependencies (PHP 8.2)"
-      if: ${{ matrix.php-versions >= '8.2' }}
+    - name: "Install Composer dependencies (PHP 8.3)"
+      if: ${{ matrix.php-versions >= '8.3' }}
       uses: "ramsey/composer-install@v2"
       with:
         composer-options: --ignore-platform-reqs


### PR DESCRIPTION
PHP 8.2 has been released today :tada: and the `setup-php` action has announced support for PHP 8.3, so adding PHP 8.3 to the matrix and no longer allowing PHP 8.2 to fail the build.

Builds against PHP 8.3 are still allowed to fail for now.