### PR TITLE
Handle PHP 8.1 "never" return type

### DIFF
--- a/src/Exceptions.php
+++ b/src/Exceptions.php
@@ -119,3 +119,8 @@ class NonNullToVoid extends Exception
 {
 	protected $message = 'A redefinition of a void-typed callable attempted to return a non-null result';
 }
+
+class ReturnFromNever extends Exception
+{
+	protected $message = 'A redefinition of a never-typed callable attempted to return';
+}

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -44,7 +44,7 @@ function runningOnHHVM()
 
 function condense($string)
 {
-    return preg_replace('/\s*/', '', $string);
+    return preg_replace('/\s+/', ' ', $string);
 }
 
 function indexOfFirstGreaterThan(array $array, $value)

--- a/tests/apply-remove.phpt
+++ b/tests/apply-remove.phpt
@@ -4,8 +4,7 @@ Applying and removing patches
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/apply-scheduled-patches-only-once.phpt
+++ b/tests/apply-scheduled-patches-only-once.phpt
@@ -4,8 +4,7 @@ Apply scheduled patches once
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/arguments.phpt
+++ b/tests/arguments.phpt
@@ -4,8 +4,7 @@ Accessing and altering arguments from patches
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/binary-search-bug.phpt
+++ b/tests/binary-search-bug.phpt
@@ -4,8 +4,7 @@ Binary search bug: https://github.com/antecedent/patchwork/issues/16
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/call-original.phpt
+++ b/tests/call-original.phpt
@@ -6,8 +6,7 @@ Calling the original function/method from a redefinition
 
 use Patchwork as p;
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/closure-this.phpt
+++ b/tests/closure-this.phpt
@@ -4,8 +4,7 @@ Automatic binding of $this on closures used as method redefinitions
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/constructor-with-parent-user-func.phpt
+++ b/tests/constructor-with-parent-user-func.phpt
@@ -4,8 +4,7 @@ Compatibility with call_user_func calling parent constructor.
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 $_SERVER['PHP_SELF'] = __FILE__;

--- a/tests/constructor-with-reference-args.phpt
+++ b/tests/constructor-with-reference-args.phpt
@@ -4,8 +4,7 @@ https://github.com/antecedent/patchwork/issues/73
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 $_SERVER['PHP_SELF'] = __FILE__;

--- a/tests/double-colon-class.phpt
+++ b/tests/double-colon-class.phpt
@@ -8,8 +8,7 @@ Compatibility with ::class syntax (https://github.com/antecedent/patchwork/issue
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/eval.phpt
+++ b/tests/eval.phpt
@@ -4,8 +4,7 @@ Preprocessing of eval'd code
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/generator.phpt
+++ b/tests/generator.phpt
@@ -8,8 +8,7 @@ Generator support is currently excluded: https://github.com/antecedent/patchwork
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/includes/NeverTyped.php
+++ b/tests/includes/NeverTyped.php
@@ -1,0 +1,13 @@
+<?php
+
+class NeverTypedException extends Exception {
+}
+
+function iAmNeverTyped() : never
+{
+    throw new NeverTypedException( 'A never-typed function must exit or throw, so we throw.' );
+}
+
+function iAmNotNeverTyped()
+{
+}

--- a/tests/inheritance-delayed-redefinition.phpt
+++ b/tests/inheritance-delayed-redefinition.phpt
@@ -4,8 +4,7 @@ Inheriting method patches + delayed redefinition (suspected HHVM issue)
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/inheritance.phpt
+++ b/tests/inheritance.phpt
@@ -4,8 +4,7 @@ Inheriting method patches (https://github.com/antecedent/patchwork/issues/4#issu
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/instance-binding.phpt
+++ b/tests/instance-binding.phpt
@@ -4,8 +4,7 @@ Automatic binding of patches to object instances
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/internals.phpt
+++ b/tests/internals.phpt
@@ -8,8 +8,7 @@ Redefinition of internal functions
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 $_SERVER['PHP_SELF'] = __FILE__;

--- a/tests/language-constructs.phpt
+++ b/tests/language-constructs.phpt
@@ -10,8 +10,7 @@ Redefining language constructs like die(), echo, require_once etc. (https://gith
 
 namespace Patchwork;
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 $_SERVER['PHP_SELF'] = __FILE__;

--- a/tests/leading-backslash.phpt
+++ b/tests/leading-backslash.phpt
@@ -4,8 +4,7 @@ Referring to namespaced functions with and without a leading backslash (https://
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/multiple-patches.phpt
+++ b/tests/multiple-patches.phpt
@@ -4,8 +4,7 @@ Applying multiple patches to the same function
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/namespace-aliasing.phpt
+++ b/tests/namespace-aliasing.phpt
@@ -4,8 +4,7 @@ https://github.com/antecedent/patchwork/issues/70
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/namespace-resolution.phpt
+++ b/tests/namespace-resolution.phpt
@@ -4,8 +4,7 @@ https://github.com/antecedent/patchwork/issues/70
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/never-typed.phpt
+++ b/tests/never-typed.phpt
@@ -7,8 +7,7 @@ https://github.com/antecedent/patchwork/issues/140
 
 --FILE--
 <?php
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/NeverTyped.php";

--- a/tests/never-typed.phpt
+++ b/tests/never-typed.phpt
@@ -1,0 +1,52 @@
+--TEST--
+https://github.com/antecedent/patchwork/issues/140
+
+--SKIPIF--
+<?php version_compare(PHP_VERSION, "8.1", ">=")
+      or die("skip because this bug only occurs in PHP 8.1") ?>
+
+--FILE--
+<?php
+assert_options(ASSERT_ACTIVE, 1);
+assert_options(ASSERT_WARNING, 1);
+error_reporting(E_ALL | E_STRICT);
+require __DIR__ . "/../Patchwork.php";
+require __DIR__ . "/includes/NeverTyped.php";
+
+class NeverTypedTestException extends Exception {
+}
+
+$n = 0;
+
+$countCalls = function() use (&$n) {
+	$n++;
+};
+$countCallsAndThrow = function() use (&$n) {
+	$n++;
+        throw new NeverTypedTestException;
+};
+
+Patchwork\redefine('iAmNeverTyped', $countCallsAndThrow);
+Patchwork\redefine('iAmNotNeverTyped', $countCalls);
+
+try {
+    iAmNeverTyped();
+    echo "Did not throw expected NeverTypedTestException exception\n";
+} catch ( NeverTypedTestException $ex ) {
+}
+iAmNotNeverTyped();
+
+assert($n === 2);
+
+Patchwork\redefine('iAmNeverTyped', $countCalls);
+try {
+    iAmNeverTyped();
+    echo "Did not throw expected \\Patchwork\\Exceptions\\ReturnFromNever exception\n";
+} catch ( \Patchwork\Exceptions\ReturnFromNever $ex ) {
+}
+
+?>
+===DONE===
+
+--EXPECT--
+===DONE===

--- a/tests/new-line-bug.phpt
+++ b/tests/new-line-bug.phpt
@@ -4,8 +4,7 @@ https://github.com/antecedent/patchwork/issues/94
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 date_default_timezone_set('UTC');

--- a/tests/new-static.phpt
+++ b/tests/new-static.phpt
@@ -4,8 +4,7 @@ https://github.com/antecedent/patchwork/issues/69
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/no-result.phpt
+++ b/tests/no-result.phpt
@@ -4,8 +4,7 @@ Leaving a patch without yielding a result
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/other-stream-wrapper-after.phpt
+++ b/tests/other-stream-wrapper-after.phpt
@@ -5,8 +5,7 @@ Case 1/2: the other stream wrapper is registered AFTER importing Patchwork.
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/other-stream-wrapper-before.phpt
+++ b/tests/other-stream-wrapper-before.phpt
@@ -5,8 +5,7 @@ Case 2/2: the other stream wrapper is registered BEFORE importing Patchwork.
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/includes/StreamWrapperForTesting.php";

--- a/tests/patchability.phpt
+++ b/tests/patchability.phpt
@@ -4,8 +4,7 @@ Not allowing to patch functions that are not defined or not preprocessed
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 $_SERVER['PHP_SELF'] = __FILE__;

--- a/tests/php5-define-bug.phpt
+++ b/tests/php5-define-bug.phpt
@@ -4,8 +4,7 @@ https://github.com/antecedent/patchwork/issues/75
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 $_SERVER['PHP_SELF'] = __FILE__;

--- a/tests/php7-use-function.phpt
+++ b/tests/php7-use-function.phpt
@@ -8,8 +8,7 @@ https://github.com/antecedent/patchwork/issues/63
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/php71-void-return-type.phpt
+++ b/tests/php71-void-return-type.phpt
@@ -8,8 +8,7 @@ https://github.com/antecedent/patchwork/issues/64
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/redefine-new-anonymous-class-parameter.phpt
+++ b/tests/redefine-new-anonymous-class-parameter.phpt
@@ -8,8 +8,7 @@ https://github.com/antecedent/patchwork/issues/127
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 $_SERVER['PHP_SELF'] = __FILE__;

--- a/tests/redefine-new-namespace-bug.phpt
+++ b/tests/redefine-new-namespace-bug.phpt
@@ -4,8 +4,7 @@ https://github.com/antecedent/patchwork/issues/126
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 $_SERVER['PHP_SELF'] = __FILE__;

--- a/tests/redefine-new.phpt
+++ b/tests/redefine-new.phpt
@@ -4,8 +4,7 @@ https://github.com/antecedent/patchwork/issues/54, https://github.com/antecedent
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 $_SERVER['PHP_SELF'] = __FILE__;

--- a/tests/require-missing-php5.phpt
+++ b/tests/require-missing-php5.phpt
@@ -10,8 +10,7 @@ version_compare(PHP_VERSION, "8.0", "<") or die("skip PHP 5 version of the test 
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/require-missing-php5.phpt
+++ b/tests/require-missing-php5.phpt
@@ -31,15 +31,15 @@ Including missing file...
 
 Warning: fopen(%s/includes/does-not-exist.php): failed to open stream: No such file or directory in %s%esrc%eCodeManipulation%eStream.php on line %d
 
-Warning: include(%s/includes/does-not-exist.php): failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in %s on line 10
+Warning: include(%s/includes/does-not-exist.php): failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in %s on line 9
 
-Warning: include(): Failed opening '%s/includes/does-not-exist.php' for inclusion (include_path='%s') in %s on line 10
+Warning: include(): Failed opening '%s/includes/does-not-exist.php' for inclusion (include_path='%s') in %s on line 9
 Good, it did not throw/exit.
 
 Requiring missing file...
 
 Warning: fopen(%s/includes/does-not-exist.php): failed to open stream: No such file or directory in %s%esrc%eCodeManipulation%eStream.php on line %d
 
-Warning: require(%s/includes/does-not-exist.php): failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in %s on line 14
+Warning: require(%s/includes/does-not-exist.php): failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in %s on line 13
 
-Fatal error: require(): Failed opening required '%s/includes/does-not-exist.php' (include_path='%s') in %s on line 14
+Fatal error: require(): Failed opening required '%s/includes/does-not-exist.php' (include_path='%s') in %s on line 13

--- a/tests/require-missing.phpt
+++ b/tests/require-missing.phpt
@@ -31,18 +31,18 @@ Including missing file...
 
 Warning: fopen(%s/includes/does-not-exist.php): Failed to open stream: No such file or directory in %s%esrc%eCodeManipulation%eStream.php on line %d
 
-Warning: include(%s/includes/does-not-exist.php): Failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in %s on line 10
+Warning: include(%s/includes/does-not-exist.php): Failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in %s on line 9
 
-Warning: include(): Failed opening '%s/includes/does-not-exist.php' for inclusion (include_path='%s') in %s on line 10
+Warning: include(): Failed opening '%s/includes/does-not-exist.php' for inclusion (include_path='%s') in %s on line 9
 Good, it did not throw/exit.
 
 Requiring missing file...
 
 Warning: fopen(%s/includes/does-not-exist.php): Failed to open stream: No such file or directory in %s%esrc%eCodeManipulation%eStream.php on line %d
 
-Warning: require(%s/includes/does-not-exist.php): Failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in %s on line 14
+Warning: require(%s/includes/does-not-exist.php): Failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in %s on line 13
 
-Fatal error: Uncaught Error: Failed opening required '%s/includes/does-not-exist.php' (include_path='%s') in %s:14
+Fatal error: Uncaught Error: Failed opening required '%s/includes/does-not-exist.php' (include_path='%s') in %s:13
 Stack trace:
 #0 {main}
-  thrown in %s on line 14
+  thrown in %s on line 13

--- a/tests/require-missing.phpt
+++ b/tests/require-missing.phpt
@@ -10,8 +10,7 @@ version_compare(PHP_VERSION, "8.0", ">=") or die("skip PHP 8+ version of the tes
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/splat.phpt
+++ b/tests/splat.phpt
@@ -15,8 +15,7 @@ version_compare(PHP_VERSION, "5.6", ">=")
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 $_SERVER['PHP_SELF'] = __FILE__;

--- a/tests/stack-inspection.phpt
+++ b/tests/stack-inspection.phpt
@@ -4,8 +4,7 @@ Retrieving call details from inside a patch
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/stream-url-stat.phpt
+++ b/tests/stream-url-stat.phpt
@@ -8,8 +8,7 @@ Test url_stat implementation - https://github.com/antecedent/patchwork/issues/11
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/strict-types.phpt
+++ b/tests/strict-types.phpt
@@ -8,8 +8,7 @@ https://github.com/antecedent/patchwork/issues/79
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/traits-delayed-redefinition.phpt
+++ b/tests/traits-delayed-redefinition.phpt
@@ -4,8 +4,7 @@ Patching methods imported from traits using Patchwork\replaceLater (https://gith
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/traits.phpt
+++ b/tests/traits.phpt
@@ -4,8 +4,7 @@ Patching methods imported from traits (https://github.com/antecedent/patchwork/i
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . "/../Patchwork.php";

--- a/tests/variadics-bug.phpt
+++ b/tests/variadics-bug.phpt
@@ -7,8 +7,7 @@ https://github.com/antecedent/patchwork/issues/114
 
 --FILE--
 <?php
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/VariadicsBug.php";

--- a/tests/variadics-ref-bug.phpt
+++ b/tests/variadics-ref-bug.phpt
@@ -7,8 +7,7 @@ https://github.com/antecedent/patchwork/issues/115
 
 --FILE--
 <?php
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/VariadicsRefBug.php";

--- a/tests/void-typed.phpt
+++ b/tests/void-typed.phpt
@@ -7,8 +7,7 @@ https://github.com/antecedent/patchwork/issues/95
 
 --FILE--
 <?php
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/VoidTyped.php";

--- a/tests/void-typed.phpt
+++ b/tests/void-typed.phpt
@@ -27,6 +27,18 @@ iAmNotVoidTyped();
 
 assert($n === 2);
 
+$returnValue = function() {
+    return 42;
+};
+Patchwork\redefine('iAmVoidTyped', $returnValue);
+Patchwork\redefine('iAmNotVoidTyped', $returnValue);
+try {
+    iAmVoidTyped();
+    echo "Did not throw expected \\Patchwork\\Exceptions\\NonNullToVoid exception\n";
+} catch(\Patchwork\Exceptions\NonNullToVoid $ex) {
+}
+iAmNotVoidTyped();
+
 ?>
 ===DONE===
 

--- a/tests/wildcard-class-instance.phpt
+++ b/tests/wildcard-class-instance.phpt
@@ -4,8 +4,7 @@ Wildcards: redefine([$instance, '*'], 'catchAll') etc.
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . '/../Patchwork.php';

--- a/tests/wildcards-and-restoreall.phpt
+++ b/tests/wildcards-and-restoreall.phpt
@@ -4,8 +4,7 @@ https://github.com/antecedent/patchwork/issues/33
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . '/../Patchwork.php';

--- a/tests/wildcards.phpt
+++ b/tests/wildcards.phpt
@@ -4,8 +4,7 @@ Wildcards: redefine('*', 'catchAll') etc.
 --FILE--
 <?php
 
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 1);
+ini_set('zend.assertions', 1);
 error_reporting(E_ALL | E_STRICT);
 
 require __DIR__ . '/../Patchwork.php';


### PR DESCRIPTION
PHP 8.1 added a "never" return type that indicates that the function will never return, and raises a fatal error if such a function includes a `return`. We need to detect and handle such functions in a similar manner as we handle "void".

Also it turns out that the error handling for a "void" redefinition trying to return a value was broken, giving an error like
```
Fatal error: Uncaught Error: Undefined constant "thrownew\Patchwork\Exceptions\NonNullToVoid" in file line #
```
so I added a test for that too and adjusted the condense function to collapse whitespace to a single space instead of stripping it completely.

Fixes #140