### PR TITLE
Remove support for HHVM

### DIFF
--- a/Patchwork.php
+++ b/Patchwork.php
@@ -107,13 +107,6 @@ configure();
 
 Utils\markMissedCallables();
 
-if (Utils\runningOnHHVM()) {
-    # no preprocessor needed on HHVM;
-    # just let Patchwork become a wrapper for fb_intercept()
-    spl_autoload_register('Patchwork\CallRerouting\deployQueue');
-    return;
-}
-
 CodeManipulation\Stream::discoverOtherWrapper();
 CodeManipulation\Stream::wrap();
 

--- a/src/Exceptions.php
+++ b/src/Exceptions.php
@@ -52,6 +52,9 @@ class InternalMethodsNotSupported extends CallbackException
     protected $message = "Methods of internal classes (such as %s) are not yet redefinable in Patchwork 2.1.";
 }
 
+/**
+ * @deprecated 2.2.0
+ */
 class InternalsNotSupportedOnHHVM extends CallbackException
 {
     protected $message = "As of version 2.1, Patchwork cannot redefine internal functions and methods (such as %s) on HHVM.";

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -37,6 +37,9 @@ function generatorsSupported()
     return version_compare(PHP_VERSION, "5.5", ">=");
 }
 
+/**
+ * @deprecated 2.2.0
+ */
 function runningOnHHVM()
 {
     return defined("HHVM_VERSION");
@@ -235,18 +238,8 @@ function getUserDefinedMethods()
     static $traitCount = 0;
     $classes = getUserDefinedClasses();
     $traits = getUserDefinedTraits();
-    if (runningOnHHVM()) {
-        # cannot rely on the order of get_declared_classes()
-        static $previousClasses = [];
-        static $previousTraits = [];
-        $newClasses = array_diff($classes, $previousClasses);
-        $newTraits = array_diff($traits, $previousTraits);
-        $previousClasses = $classes;
-        $previousTraits = $traits;
-    } else {
-        $newClasses = array_slice($classes, $classCount);
-        $newTraits = array_slice($traits, $traitCount);
-    }
+    $newClasses = array_slice($classes, $classCount);
+    $newTraits = array_slice($traits, $traitCount);
     foreach (array_merge($newClasses, $newTraits) as $newClass) {
         foreach (get_class_methods($newClass) as $method) {
             $result[] = $newClass . '::' . $method;

--- a/tests/inheritance-delayed-redefinition.phpt
+++ b/tests/inheritance-delayed-redefinition.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Inheriting method patches + delayed redefinition (suspected HHVM issue)
+Inheriting method patches + delayed redefinition
 
 --FILE--
 <?php

--- a/tests/internals.phpt
+++ b/tests/internals.phpt
@@ -1,10 +1,6 @@
 --TEST--
 Redefinition of internal functions
 
---SKIPIF--
-<?php !defined('HHVM_VERSION')
-      or die('skip because the redefinition of internals is not yet implemented for HHVM') ?>
-
 --FILE--
 <?php
 

--- a/tests/language-constructs.phpt
+++ b/tests/language-constructs.phpt
@@ -1,10 +1,6 @@
 --TEST--
 Redefining language constructs like die(), echo, require_once etc. (https://github.com/antecedent/patchwork/issues/59)
 
---SKIPIF--
-<?php !defined('HHVM_VERSION')
-      or die('skip because the redefinition of language constructs is not yet implemented for HHVM') ?>
-
 --FILE--
 <?php
 

--- a/tests/patchability.phpt
+++ b/tests/patchability.phpt
@@ -18,20 +18,16 @@ function functionThatIsNotPreprocessed()
 
 assert(Patchwork\hasMissed('functionThatIsNotPreprocessed'));
 
-if (!Patchwork\Utils\runningOnHHVM()) {
-	expectException('Patchwork\Exceptions\DefinedTooEarly', function() {
-	    Patchwork\replace("functionThatIsNotPreprocessed", Patchwork\always(null));
-	});
-}
+expectException('Patchwork\Exceptions\DefinedTooEarly', function() {
+    Patchwork\replace("functionThatIsNotPreprocessed", Patchwork\always(null));
+});
 
 $h = Patchwork\replace("functionThatIsNotDefined", Patchwork\always(null));
 Patchwork\assertEventuallyDefined($h);
 
-if (!Patchwork\Utils\runningOnHHVM()) {
-	expectException('Patchwork\Exceptions\DefinedTooEarly', function() {
-	    Patchwork\replaceLater("functionThatIsNotPreprocessed", Patchwork\always(null));
-	});
-}
+expectException('Patchwork\Exceptions\DefinedTooEarly', function() {
+    Patchwork\replaceLater("functionThatIsNotPreprocessed", Patchwork\always(null));
+});
 
 Patchwork\replaceLater("getInteger", function() {
     return 42;
@@ -43,11 +39,9 @@ assert(getInteger() === 42);
 
 require __DIR__ . "/includes/Singleton.php";
 
-if (!Patchwork\Utils\runningOnHHVM()) {
-	expectException('Patchwork\Exceptions\DefinedTooEarly', function() {
-	    Patchwork\replace("Singleton::getInstance", Patchwork\always(null));
-	});
-}
+expectException('Patchwork\Exceptions\DefinedTooEarly', function() {
+    Patchwork\replace("Singleton::getInstance", Patchwork\always(null));
+});
 
 $h = Patchwork\replace('anotherUndefinedFunction', Patchwork\always(null));
 Patchwork\assertEventuallyDefined($h);

--- a/tests/splat.phpt
+++ b/tests/splat.phpt
@@ -7,9 +7,6 @@ https://github.com/antecedent/patchwork/issues/56
 version_compare(PHP_VERSION, "5.6", ">=")
     or die("skip because this bug only occurs in PHP 5.6 and up");
 
-!defined('HHVM_VERSION')
-    or die('skip because the redefinition of internals is not yet implemented for HHVM');
-
 ?>
 
 --FILE--


### PR DESCRIPTION
HHVM dropped support for PHP at the end of 2018.

While testing and basic support for HHVM was enabled in Patchwork, it has basically been broken since then and the tests aren't being run against HHVM anyway.

So, let's formally drop support for it and remove all references to it.

This commit actions this in the following manner:
* Mark dedicated functions/classes related to HHVM as (soft) deprecated.
* Remove all conditionals in the codebase related to HHVM.

Follow-up actions:
* I suggest opening an issue for `2.last` to hard deprecate the functions/classes (i.e. trigger a deprecation notice).
* I also suggest opening an issue for 3.0 to remove the deprecated functions/classes.

Ref: https://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html

Fixes #139