### PR TITLE
PHP 8.4 | Console: remove use of `E_STRICT`

### DIFF
--- a/src/Console.php
+++ b/src/Console.php
@@ -10,7 +10,7 @@ namespace Patchwork\Console;
 
 use Patchwork\CodeManipulation as CM;
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $argc > 2 && $argv[1] == 'prime'
     or exit("\nUsage: php patchwork.phar prime DIR1 DIR2 ... DIRn\n" .


### PR DESCRIPTION
The `E_STRICT` constant is deprecated as of PHP 8.4 and will be removed in PHP 9.0.

The error level hasn't been in use since PHP 8.0 anyway and was only barely still used in PHP 7.x, so removing the exclusion from the `error_reporting()` setting in the `Console` script shouldn't really make any difference in practice.

Ref:
* https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant