### PR TITLE
PHP 8.4 | Silence deprecation for trigger_error()

### DIFF
--- a/tests/includes/TestUtils.php
+++ b/tests/includes/TestUtils.php
@@ -1,13 +1,19 @@
 <?php
 
+class ExceptionNotThrown extends Exception {}
+class WrongExceptionThrown extends Exception {}
+
 function expectException($type, $callback)
 {
     try {
         call_user_func($callback);
-        trigger_error("No exception thrown", E_USER_ERROR);
+        throw new ExceptionNotThrown('No exception thrown');
+    } catch (ExceptionNotThrown $e) {
+        // Rethrow the exception.
+        throw $e;
     } catch (Exception $e) {
         if (!$e instanceof $type) {
-            trigger_error("No exception of type $type thrown", E_USER_ERROR);
+            throw new WrongExceptionThrown("No exception of type $type thrown");
         }
     }
 }


### PR DESCRIPTION
PHP 8.4 deprecates passing `E_USER_ERROR` to `trigger_error()`, suggesting to use exceptions or `exit` instead.

This updates the exception handling in the test suite to avoid the deprecation and still continue to function as before, with the only difference being in the errors which are shown.

```diff
-Fatal error: No exception thrown in * on line *'
+'Fatal error: Uncaught ExceptionNotThrown: No exception thrown in *:*\n

-Fatal error: No exception of type RuntimeExsception thrown in * on line *'
+'Fatal error: Uncaught WrongExceptionThrown: No exception of type RuntimeExsception thrown in *:*\n
```

Ref: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error

Related to #157