### PR TITLE
Drop support for PHP < 7.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,10 +7,6 @@ jobs:
       fail-fast: false
       matrix:
         php-versions:
-        - '5.4'
-        - '5.5'
-        - '5.6'
-        - '7.0'
         - '7.1'
         - '7.2'
         - '7.3'

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=7.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=4"

--- a/src/CodeManipulation/Actions/Generic.php
+++ b/src/CodeManipulation/Actions/Generic.php
@@ -57,12 +57,10 @@ function prependCodeToFunctions($code, $typedVariants = array(), $fillArgRefs = 
                 $argRefs = Arguments\constructReferenceArray($args);
             }
             $bracket = $s->next(LEFT_CURLY, $function);
-            if (Utils\generatorsSupported()) {
-                # Skip generators
-                $yield = $s->next(T_YIELD, $bracket);
-                if ($yield < $s->match($bracket)) {
-                    continue;
-                }
+            # Skip generators
+            $yield = $s->next(T_YIELD, $bracket);
+            if ($yield < $s->match($bracket)) {
+                continue;
             }
             $semicolon = $s->next(SEMICOLON, $function);
             if ($bracket < $semicolon) {

--- a/src/CodeManipulation/Stream.php
+++ b/src/CodeManipulation/Stream.php
@@ -59,7 +59,7 @@ class Stream
     {
         $including = (bool) ($options & self::STREAM_OPEN_FOR_INCLUDE);
 
-        // In PHP 7 and 8, `parse_ini_file()` also sets STREAM_OPEN_FOR_INCLUDE.
+        // `parse_ini_file()` also sets STREAM_OPEN_FOR_INCLUDE.
         if ($including) {
             $frame = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1];
             if (empty($frame['class']) && $frame['function'] === 'parse_ini_file') {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -32,6 +32,9 @@ function clearOpcodeCaches()
     }
 }
 
+/**
+ * @deprecated 2.2.0
+ */
 function generatorsSupported()
 {
     return version_compare(PHP_VERSION, "5.5", ">=");

--- a/tests/double-colon-class.phpt
+++ b/tests/double-colon-class.phpt
@@ -1,10 +1,6 @@
 --TEST--
 Compatibility with ::class syntax (https://github.com/antecedent/patchwork/issues/14)
 
---SKIPIF--
-<?php version_compare(PHP_VERSION, "5.5", ">=")
-      or die("skip because ::class syntax is unsupported in this version of PHP") ?>
-
 --FILE--
 <?php
 

--- a/tests/generator.phpt
+++ b/tests/generator.phpt
@@ -1,10 +1,6 @@
 --TEST--
 Generator support is currently excluded: https://github.com/antecedent/patchwork/issues/15
 
---SKIPIF--
-<?php version_compare(PHP_VERSION, "5.5", ">=")
-      or die("skip because generators are not supported in this version of PHP") ?>
-
 --FILE--
 <?php
 

--- a/tests/includes/ProxyForInternals.php
+++ b/tests/includes/ProxyForInternals.php
@@ -52,9 +52,7 @@ p\redefine('sort', function(&$array) {
 assert(isset($array['original']));
 
 # Aliases
-if (version_compare(PHP_VERSION, "7.0", ">=")) {
-    eval('use function strtolower as toLower; assert(toLower("X") === "X, but in lowercase");');
-}
+eval('use function strtolower as toLower; assert(toLower("X") === "X, but in lowercase");');
 
 p\restoreAll();
 

--- a/tests/php7-parenthesis-removal-bug.phpt
+++ b/tests/php7-parenthesis-removal-bug.phpt
@@ -1,10 +1,6 @@
 --TEST--
 https://github.com/antecedent/patchwork/issues/147
 
---SKIPIF--
-<?php version_compare(PHP_VERSION, "7.0", ">=")
-      or die("skip because this bug only occurs in PHP 7+") ?>
-
 --FILE--
 <?php
 

--- a/tests/php7-use-function.phpt
+++ b/tests/php7-use-function.phpt
@@ -1,10 +1,6 @@
 --TEST--
 https://github.com/antecedent/patchwork/issues/63
 
---SKIPIF--
-<?php version_compare(PHP_VERSION, "7.0", ">=")
-      or die("skip because this bug only occurs in PHP 7") ?>
-
 --FILE--
 <?php
 

--- a/tests/php71-void-return-type.phpt
+++ b/tests/php71-void-return-type.phpt
@@ -1,10 +1,6 @@
 --TEST--
 https://github.com/antecedent/patchwork/issues/64
 
---SKIPIF--
-<?php version_compare(PHP_VERSION, "7.1", ">=")
-      or die("skip because this bug only occurs in PHP 7.1") ?>
-
 --FILE--
 <?php
 

--- a/tests/redefine-new-anonymous-class-parameter.phpt
+++ b/tests/redefine-new-anonymous-class-parameter.phpt
@@ -1,10 +1,6 @@
 --TEST--
 https://github.com/antecedent/patchwork/issues/127
 
---SKIPIF--
-<?php version_compare(PHP_VERSION, "7.0", ">=")
-      or die("skip because anonymous classes are only supported since PHP 7") ?>
-
 --FILE--
 <?php
 

--- a/tests/splat.phpt
+++ b/tests/splat.phpt
@@ -1,14 +1,6 @@
 --TEST--
 https://github.com/antecedent/patchwork/issues/56
 
---SKIPIF--
-<?php
-
-version_compare(PHP_VERSION, "5.6", ">=")
-    or die("skip because this bug only occurs in PHP 5.6 and up");
-
-?>
-
 --FILE--
 <?php
 

--- a/tests/strict-types.phpt
+++ b/tests/strict-types.phpt
@@ -1,10 +1,6 @@
 --TEST--
 https://github.com/antecedent/patchwork/issues/79
 
---SKIPIF--
-<?php version_compare(PHP_VERSION, "7.0", ">=")
-      or die("skip because strict types were only introduced in PHP 7") ?>
-
 --FILE--
 <?php
 

--- a/tests/variadics-bug.phpt
+++ b/tests/variadics-bug.phpt
@@ -1,10 +1,6 @@
 --TEST--
 https://github.com/antecedent/patchwork/issues/114
 
---SKIPIF--
-<?php version_compare(PHP_VERSION, "5.6", ">=")
-      or die("skip because variadics are not available until PHP 5.6") ?>
-
 --FILE--
 <?php
 ini_set('zend.assertions', 1);

--- a/tests/variadics-ref-bug.phpt
+++ b/tests/variadics-ref-bug.phpt
@@ -1,10 +1,6 @@
 --TEST--
 https://github.com/antecedent/patchwork/issues/115
 
---SKIPIF--
-<?php version_compare(PHP_VERSION, "5.6", ">=")
-      or die("skip because variadics are not available until PHP 5.6") ?>
-
 --FILE--
 <?php
 ini_set('zend.assertions', 1);

--- a/tests/void-typed.phpt
+++ b/tests/void-typed.phpt
@@ -1,10 +1,6 @@
 --TEST--
 https://github.com/antecedent/patchwork/issues/95
 
---SKIPIF--
-<?php version_compare(PHP_VERSION, "7.1", ">=")
-      or die("skip because this bug only occurs in PHP 7.1") ?>
-
 --FILE--
 <?php
 ini_set('zend.assertions', 1);


### PR DESCRIPTION
### Drop support for PHP < 7.1

This commit drops support for PHP < 7.1 from:
* The GH Actions workflow(s).
* Composer.
* The tests.

### Deprecate Utils\generatorsSupported()

... as it is no longer needed now support for PHP < 7.1 has been dropped.

Closes #157