### PR TITLE
PHP 8.4 | Remove use of `E_STRICT` from the tests

### DIFF
--- a/tests/anonymous-class-attribute.phpt
+++ b/tests/anonymous-class-attribute.phpt
@@ -8,7 +8,7 @@ Attribute declared in anonymous class
 --FILE--
 <?php
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/AnonymousClassAttribute.php";

--- a/tests/apply-remove.phpt
+++ b/tests/apply-remove.phpt
@@ -5,7 +5,7 @@ Applying and removing patches
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Singleton.php";

--- a/tests/apply-scheduled-patches-only-once.phpt
+++ b/tests/apply-scheduled-patches-only-once.phpt
@@ -5,7 +5,7 @@ Apply scheduled patches once
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 

--- a/tests/arguments.phpt
+++ b/tests/arguments.phpt
@@ -5,7 +5,7 @@ Accessing and altering arguments from patches
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Functions.php";

--- a/tests/binary-search-bug.phpt
+++ b/tests/binary-search-bug.phpt
@@ -5,7 +5,7 @@ Binary search bug: https://github.com/antecedent/patchwork/issues/16
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Interface.php";

--- a/tests/call-original.phpt
+++ b/tests/call-original.phpt
@@ -7,7 +7,7 @@ Calling the original function/method from a redefinition
 use Patchwork as p;
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Singleton.php";

--- a/tests/closure-this.phpt
+++ b/tests/closure-this.phpt
@@ -5,7 +5,7 @@ Automatic binding of $this on closures used as method redefinitions
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/NamedObject.php";

--- a/tests/constructor-with-parent-user-func.phpt
+++ b/tests/constructor-with-parent-user-func.phpt
@@ -5,7 +5,7 @@ Compatibility with call_user_func calling parent constructor.
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $_SERVER['PHP_SELF'] = __FILE__;
 

--- a/tests/constructor-with-reference-args.phpt
+++ b/tests/constructor-with-reference-args.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/73
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $_SERVER['PHP_SELF'] = __FILE__;
 

--- a/tests/double-colon-class.phpt
+++ b/tests/double-colon-class.phpt
@@ -5,7 +5,7 @@ Compatibility with ::class syntax (https://github.com/antecedent/patchwork/issue
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/DoubleColonClass.php";

--- a/tests/eval.phpt
+++ b/tests/eval.phpt
@@ -5,7 +5,7 @@ Preprocessing of eval'd code
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Functions.php";

--- a/tests/generator.phpt
+++ b/tests/generator.phpt
@@ -5,7 +5,7 @@ Generator support is currently excluded: https://github.com/antecedent/patchwork
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Generator.php";

--- a/tests/inheritance-delayed-redefinition.phpt
+++ b/tests/inheritance-delayed-redefinition.phpt
@@ -5,7 +5,7 @@ Inheriting method patches + delayed redefinition
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 

--- a/tests/inheritance.phpt
+++ b/tests/inheritance.phpt
@@ -5,7 +5,7 @@ Inheriting method patches (https://github.com/antecedent/patchwork/issues/4#issu
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Inheritance.php";

--- a/tests/instance-binding.phpt
+++ b/tests/instance-binding.phpt
@@ -5,7 +5,7 @@ Automatic binding of patches to object instances
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/NamedObject.php";

--- a/tests/internals.phpt
+++ b/tests/internals.phpt
@@ -5,7 +5,7 @@ Redefinition of internal functions
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $_SERVER['PHP_SELF'] = __FILE__;
 

--- a/tests/language-construct-parenthesization-bug.phpt
+++ b/tests/language-construct-parenthesization-bug.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/148
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $_SERVER['PHP_SELF'] = __FILE__;
 

--- a/tests/language-constructs.phpt
+++ b/tests/language-constructs.phpt
@@ -7,7 +7,7 @@ Redefining language constructs like die(), echo, require_once etc. (https://gith
 namespace Patchwork;
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $_SERVER['PHP_SELF'] = __FILE__;
 

--- a/tests/leading-backslash.phpt
+++ b/tests/leading-backslash.phpt
@@ -5,7 +5,7 @@ Referring to namespaced functions with and without a leading backslash (https://
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/NamespacedFunctions.php";

--- a/tests/multiple-patches.phpt
+++ b/tests/multiple-patches.phpt
@@ -5,7 +5,7 @@ Applying multiple patches to the same function
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Functions.php";

--- a/tests/namespace-aliasing.phpt
+++ b/tests/namespace-aliasing.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/70
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/NamespaceAliasing.php";

--- a/tests/namespace-resolution.phpt
+++ b/tests/namespace-resolution.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/70
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/NamespaceResolution.php";

--- a/tests/never-typed.phpt
+++ b/tests/never-typed.phpt
@@ -8,7 +8,7 @@ https://github.com/antecedent/patchwork/issues/140
 --FILE--
 <?php
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/NeverTyped.php";
 

--- a/tests/new-line-bug.phpt
+++ b/tests/new-line-bug.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/94
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 date_default_timezone_set('UTC');
 

--- a/tests/new-static.phpt
+++ b/tests/new-static.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/69
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/NewStatic.php";

--- a/tests/no-result.phpt
+++ b/tests/no-result.phpt
@@ -5,7 +5,7 @@ Leaving a patch without yielding a result
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Functions.php";

--- a/tests/other-stream-wrapper-after.phpt
+++ b/tests/other-stream-wrapper-after.phpt
@@ -6,7 +6,7 @@ Case 1/2: the other stream wrapper is registered AFTER importing Patchwork.
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/StreamWrapperForTesting.php";

--- a/tests/other-stream-wrapper-before.phpt
+++ b/tests/other-stream-wrapper-before.phpt
@@ -6,7 +6,7 @@ Case 2/2: the other stream wrapper is registered BEFORE importing Patchwork.
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/includes/StreamWrapperForTesting.php";
 require __DIR__ . "/../Patchwork.php";

--- a/tests/patchability.phpt
+++ b/tests/patchability.phpt
@@ -5,7 +5,7 @@ Not allowing to patch functions that are not defined or not preprocessed
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $_SERVER['PHP_SELF'] = __FILE__;
 

--- a/tests/php5-define-bug.phpt
+++ b/tests/php5-define-bug.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/75
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $_SERVER['PHP_SELF'] = __FILE__;
 

--- a/tests/php7-parenthesis-removal-bug.phpt
+++ b/tests/php7-parenthesis-removal-bug.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/147
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $_SERVER['PHP_SELF'] = __FILE__;
 

--- a/tests/php7-use-function.phpt
+++ b/tests/php7-use-function.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/63
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Php7UseFunction.php";

--- a/tests/php71-void-return-type.phpt
+++ b/tests/php71-void-return-type.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/64
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Php71VoidReturnType.php";

--- a/tests/php8-attributes.phpt
+++ b/tests/php8-attributes.phpt
@@ -4,7 +4,7 @@ https://github.com/antecedent/patchwork/issues/117
 --FILE--
 <?php
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Php8Attributes.php";

--- a/tests/redefine-new-anonymous-class-parameter.phpt
+++ b/tests/redefine-new-anonymous-class-parameter.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/127
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $_SERVER['PHP_SELF'] = __FILE__;
 

--- a/tests/redefine-new-namespace-bug.phpt
+++ b/tests/redefine-new-namespace-bug.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/126
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $_SERVER['PHP_SELF'] = __FILE__;
 

--- a/tests/redefine-new.phpt
+++ b/tests/redefine-new.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/54, https://github.com/antecedent
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $_SERVER['PHP_SELF'] = __FILE__;
 

--- a/tests/redefinition-new-anonymous-class-with-attribute.phpt
+++ b/tests/redefinition-new-anonymous-class-with-attribute.phpt
@@ -8,7 +8,7 @@ Redefinition of new in anonymous class with attribute
 --FILE--
 <?php
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $_SERVER['PHP_SELF'] = __FILE__;
 

--- a/tests/require-missing-php5.phpt
+++ b/tests/require-missing-php5.phpt
@@ -11,7 +11,7 @@ version_compare(PHP_VERSION, "8.0", "<") or die("skip PHP 5 version of the test 
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 

--- a/tests/require-missing.phpt
+++ b/tests/require-missing.phpt
@@ -11,7 +11,7 @@ version_compare(PHP_VERSION, "8.0", ">=") or die("skip PHP 8+ version of the tes
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 

--- a/tests/splat.phpt
+++ b/tests/splat.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/56
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 $_SERVER['PHP_SELF'] = __FILE__;
 

--- a/tests/stack-inspection.phpt
+++ b/tests/stack-inspection.phpt
@@ -5,7 +5,7 @@ Retrieving call details from inside a patch
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/TestUtils.php";

--- a/tests/stream-url-stat.phpt
+++ b/tests/stream-url-stat.phpt
@@ -9,7 +9,7 @@ Test url_stat implementation - https://github.com/antecedent/patchwork/issues/11
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 

--- a/tests/strict-types.phpt
+++ b/tests/strict-types.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/79
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/StrictTypes.php";

--- a/tests/traits-delayed-redefinition.phpt
+++ b/tests/traits-delayed-redefinition.phpt
@@ -5,7 +5,7 @@ Patching methods imported from traits using Patchwork\replaceLater (https://gith
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 

--- a/tests/traits.phpt
+++ b/tests/traits.phpt
@@ -5,7 +5,7 @@ Patching methods imported from traits (https://github.com/antecedent/patchwork/i
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/Traits.php";

--- a/tests/variadics-bug.phpt
+++ b/tests/variadics-bug.phpt
@@ -4,7 +4,7 @@ https://github.com/antecedent/patchwork/issues/114
 --FILE--
 <?php
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/VariadicsBug.php";
 

--- a/tests/variadics-ref-bug.phpt
+++ b/tests/variadics-ref-bug.phpt
@@ -4,7 +4,7 @@ https://github.com/antecedent/patchwork/issues/115
 --FILE--
 <?php
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/VariadicsRefBug.php";
 

--- a/tests/void-typed.phpt
+++ b/tests/void-typed.phpt
@@ -4,7 +4,7 @@ https://github.com/antecedent/patchwork/issues/95
 --FILE--
 <?php
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/VoidTyped.php";
 

--- a/tests/wildcard-class-instance.phpt
+++ b/tests/wildcard-class-instance.phpt
@@ -5,7 +5,7 @@ Wildcards: redefine([$instance, '*'], 'catchAll') etc.
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . '/../Patchwork.php';
 require __DIR__ . '/includes/Functions.php';

--- a/tests/wildcards-and-restoreall.phpt
+++ b/tests/wildcards-and-restoreall.phpt
@@ -5,7 +5,7 @@ https://github.com/antecedent/patchwork/issues/33
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . '/../Patchwork.php';
 require __DIR__ . '/includes/Inheritance.php';

--- a/tests/wildcards.phpt
+++ b/tests/wildcards.phpt
@@ -5,7 +5,7 @@ Wildcards: redefine('*', 'catchAll') etc.
 <?php
 
 ini_set('zend.assertions', 1);
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require __DIR__ . '/../Patchwork.php';
 require __DIR__ . '/includes/Functions.php';


### PR DESCRIPTION
The `E_STRICT` constant is deprecated as of PHP 8.4 and will be removed in PHP 9.0.

The error level hasn't been in use since PHP 8.0 anyway and was only barely still used in PHP 7.x, so removing the exclusion from the `error_reporting()` setting in the `Console` script shouldn't really make any difference in practice.

Ref:
* https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant

Related to #157