### PR TITLE
Don't use die() but echo to skip tests.

### DIFF
--- a/tests/anonymous-class-attribute.phpt
+++ b/tests/anonymous-class-attribute.phpt
@@ -3,7 +3,9 @@ Attribute declared in anonymous class
 
 --SKIPIF--
 <?php
-if (!version_compare(PHP_VERSION, "8.0", ">=")) echo "skip because attributes are only available since PHP 8.0";
+if (!version_compare(PHP_VERSION, "8.0", ">=")) {
+    echo "skip because attributes are only available since PHP 8.0";
+}
 --FILE--
 <?php
 

--- a/tests/anonymous-class-attribute.phpt
+++ b/tests/anonymous-class-attribute.phpt
@@ -2,9 +2,8 @@
 Attribute declared in anonymous class
 
 --SKIPIF--
-<?php version_compare(PHP_VERSION, "8.0", ">=")
-      or die("skip because attributes are only available since PHP 8.0") ?>
-
+<?php
+if (!version_compare(PHP_VERSION, "8.0", ">=")) echo "skip because attributes are only available since PHP 8.0";
 --FILE--
 <?php
 

--- a/tests/never-typed.phpt
+++ b/tests/never-typed.phpt
@@ -3,7 +3,9 @@ https://github.com/antecedent/patchwork/issues/140
 
 --SKIPIF--
 <?php
-if (!version_compare(PHP_VERSION, "8.1", ">=")) echo "skip because this bug only occurs in PHP 8.1";
+if (!version_compare(PHP_VERSION, "8.1", ">=")) {
+    echo "skip because this bug only occurs in PHP 8.1";
+}
 --FILE--
 <?php
 ini_set('zend.assertions', 1);

--- a/tests/never-typed.phpt
+++ b/tests/never-typed.phpt
@@ -2,9 +2,8 @@
 https://github.com/antecedent/patchwork/issues/140
 
 --SKIPIF--
-<?php version_compare(PHP_VERSION, "8.1", ">=")
-      or die("skip because this bug only occurs in PHP 8.1") ?>
-
+<?php
+if (!version_compare(PHP_VERSION, "8.1", ">=")) echo "skip because this bug only occurs in PHP 8.1";
 --FILE--
 <?php
 ini_set('zend.assertions', 1);

--- a/tests/redefinition-new-anonymous-class-with-attribute.phpt
+++ b/tests/redefinition-new-anonymous-class-with-attribute.phpt
@@ -2,9 +2,8 @@
 Redefinition of new in anonymous class with attribute
 
 --SKIPIF--
-<?php version_compare(PHP_VERSION, "8.0", ">=")
-      or die("skip because attributes are only available since PHP 8.0") ?>
-
+<?php
+if (!version_compare(PHP_VERSION, "8.0", ">=")) echo "skip because attributes are only available since PHP 8.0";
 --FILE--
 <?php
 

--- a/tests/redefinition-new-anonymous-class-with-attribute.phpt
+++ b/tests/redefinition-new-anonymous-class-with-attribute.phpt
@@ -3,7 +3,9 @@ Redefinition of new in anonymous class with attribute
 
 --SKIPIF--
 <?php
-if (!version_compare(PHP_VERSION, "8.0", ">=")) echo "skip because attributes are only available since PHP 8.0";
+if (!version_compare(PHP_VERSION, "8.0", ">=")) {
+    echo "skip because attributes are only available since PHP 8.0";
+}
 --FILE--
 <?php
 

--- a/tests/require-missing-php5.phpt
+++ b/tests/require-missing-php5.phpt
@@ -5,8 +5,7 @@ Include and require of nonexistent files
 <?php
 // PHP 8.0 changed require failing from a fatal error to a thrown exception. That's too much of a difference
 // to handle easily in EXPECTF, easier to just copy the file.
-version_compare(PHP_VERSION, "8.0", "<") or die("skip PHP 5 version of the test in PHP 8+");
-
+if (!version_compare(PHP_VERSION, "8.0", "<")) echo "skip PHP 5 version of the test in PHP 8+";
 --FILE--
 <?php
 

--- a/tests/require-missing-php5.phpt
+++ b/tests/require-missing-php5.phpt
@@ -5,7 +5,9 @@ Include and require of nonexistent files
 <?php
 // PHP 8.0 changed require failing from a fatal error to a thrown exception. That's too much of a difference
 // to handle easily in EXPECTF, easier to just copy the file.
-if (!version_compare(PHP_VERSION, "8.0", "<")) echo "skip PHP 5 version of the test in PHP 8+";
+if (!version_compare(PHP_VERSION, "8.0", "<")) {
+    echo "skip PHP 5 version of the test in PHP 8+";
+}
 --FILE--
 <?php
 

--- a/tests/require-missing.phpt
+++ b/tests/require-missing.phpt
@@ -5,7 +5,9 @@ Include and require of nonexistent files
 <?php
 // PHP 8.0 changed require failing from a fatal error to a thrown exception. That's too much of a difference
 // to handle easily in EXPECTF, easier to just copy the file.
-if (!version_compare(PHP_VERSION, "8.0", ">=")) echo "skip PHP 8+ version of the test in PHP <8";
+if (!version_compare(PHP_VERSION, "8.0", ">=")) {
+    echo "skip PHP 8+ version of the test in PHP <8";
+}
 --FILE--
 <?php
 

--- a/tests/require-missing.phpt
+++ b/tests/require-missing.phpt
@@ -5,8 +5,7 @@ Include and require of nonexistent files
 <?php
 // PHP 8.0 changed require failing from a fatal error to a thrown exception. That's too much of a difference
 // to handle easily in EXPECTF, easier to just copy the file.
-version_compare(PHP_VERSION, "8.0", ">=") or die("skip PHP 8+ version of the test in PHP <8");
-
+if (!version_compare(PHP_VERSION, "8.0", ">=")) echo "skip PHP 8+ version of the test in PHP <8";
 --FILE--
 <?php
 

--- a/tests/stream-url-stat.phpt
+++ b/tests/stream-url-stat.phpt
@@ -2,8 +2,9 @@
 Test url_stat implementation - https://github.com/antecedent/patchwork/issues/116
 
 --SKIPIF--
-<?php substr(PHP_OS, 0, 3) !== 'WIN'
-    or die('skip because no symlinks on Windows');
+<?php if (substr(PHP_OS, 0, 3) === 'WIN') {
+    echo 'skip because no symlinks on Windows';
+}
 
 --FILE--
 <?php


### PR DESCRIPTION
To unlock PHPUnit side-effect-free in-process `--SKIPIF--` evaluation, we use regular `echo` instead of `die()`.
That way PHPunit can detect whether conditions may be evaluated in the main-process to reduce sub-process creation overhead.

Depends on the work-inprogress of https://github.com/sebastianbergmann/phpunit/pull/5974

----

Running phpunit with the side-effect detecting PR vs. the regular master version, yields the following results in this PR on my windows laptop:

```
$ hyperfine '/c/tools/php83/php ../phpunit/phpunit tests' '/c/tools/php83/php vendor/bin/phpunit tests' --warmup=3
Benchmark 1: C:/tools/php83/php ../phpunit/phpunit tests
  Time (mean ± σ):      3.312 s ±  0.020 s    [User: 0.184 s, System: 0.510 s]
  Range (min … max):    3.291 s …  3.347 s    10 runs

Benchmark 2: C:/tools/php83/php vendor/bin/phpunit tests
  Time (mean ± σ):      3.555 s ±  0.031 s    [User: 0.220 s, System: 0.599 s]
  Range (min … max):    3.521 s …  3.604 s    10 runs

Summary
  C:/tools/php83/php ../phpunit/phpunit tests ran
    1.07 ± 0.01 times faster than C:/tools/php83/php vendor/bin/phpunit tests

$ /c/tools/php83/php -v
PHP 8.3.11 (cli) (built: Aug 27 2024 21:28:35) (NTS Visual C++ 2019 x64)
Copyright (c) The PHP Group
Zend Engine v4.3.11, Copyright (c) Zend Technologies
```

-> inline-skip-if evaluation of 7 test-cases - as proposed with this PR - will yield a 7-8% perf improvement.