### PR TITLE
GH Actions: PHP 8.4 has been released

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,9 +16,10 @@ jobs:
         - '8.2'
         - '8.3'
         - '8.4'
+        - '8.5'
     name: "PHP: ${{ matrix.php-versions }}"
 
-    continue-on-error: ${{ matrix.php-versions == '8.4' }}
+    continue-on-error: ${{ matrix.php-versions == '8.5' }}
 
     steps:
     - name: Checkout
@@ -34,15 +35,15 @@ jobs:
 
     # Install dependencies and handle caching in one go.
     # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
-    - name: "Install Composer dependencies (PHP < 8.4)"
-      if: ${{ matrix.php-versions < '8.4' }}
+    - name: "Install Composer dependencies (PHP < 8.5)"
+      if: ${{ matrix.php-versions < '8.5' }}
       uses: "ramsey/composer-install@v3"
       with:
         # Bust the cache at least once a month - output format: YYYY-MM.
         custom-cache-suffix: $(date -u "+%Y-%m")
 
-    - name: "Install Composer dependencies (PHP 8.4)"
-      if: ${{ matrix.php-versions >= '8.4' }}
+    - name: "Install Composer dependencies (PHP 8.5)"
+      if: ${{ matrix.php-versions >= '8.5' }}
       uses: "ramsey/composer-install@v3"
       with:
         composer-options: --ignore-platform-reqs


### PR DESCRIPTION
* Builds against PHP 8.4 are no longer allowed to fail.
* Add _allowed to fail_ build against PHP 8.5.

Ref: https://www.php.net/releases/8.4/en.php