### PR TITLE
Fix PHP 8.4 deprecation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 composer.lock
+tests/cache
 vendor/
 composer.phar
 .DS_Store

--- a/src/CodeManipulation.php
+++ b/src/CodeManipulation.php
@@ -64,10 +64,10 @@ function getCachedPath($file)
         $indexPath = Config\getCachePath() . '/index.csv';
         if (file_exists($indexPath)) {
             $table = array_map(
-				static function($line) {
-					return str_getcsv($line, ',', '"', '\\');
-				},
-				file($indexPath)
+        		static function($line) {
+                    return str_getcsv($line, ',', '"', '\\');
+        		},
+                file($indexPath)
             );
             foreach ($table as $row) {
                 list($key, $value) = $row;

--- a/src/CodeManipulation.php
+++ b/src/CodeManipulation.php
@@ -64,9 +64,9 @@ function getCachedPath($file)
         $indexPath = Config\getCachePath() . '/index.csv';
         if (file_exists($indexPath)) {
             $table = array_map(
-        		static function($line) {
+                static function($line) {
                     return str_getcsv($line, ',', '"', '\\');
-        		},
+                },
                 file($indexPath)
             );
             foreach ($table as $row) {

--- a/src/CodeManipulation.php
+++ b/src/CodeManipulation.php
@@ -65,7 +65,6 @@ function getCachedPath($file)
         if (file_exists($indexPath)) {
             $table = array_map(
 				static function($line) {
-					/** @noinspection PhpRedundantOptionalArgumentInspection */
 					return str_getcsv($line, ',', '"', '\\');
 				},
 				file($indexPath)

--- a/src/CodeManipulation.php
+++ b/src/CodeManipulation.php
@@ -63,7 +63,13 @@ function getCachedPath($file)
     if (State::$cacheIndexFile === null) {
         $indexPath = Config\getCachePath() . '/index.csv';
         if (file_exists($indexPath)) {
-            $table = array_map('str_getcsv', file($indexPath));
+            $table = array_map(
+				static function($line) {
+					/** @noinspection PhpRedundantOptionalArgumentInspection */
+					return str_getcsv($line, ',', '"', '\\');
+				},
+				file($indexPath)
+            );
             foreach ($table as $row) {
                 list($key, $value) = $row;
                 State::$cacheIndex[$key] = $value;

--- a/tests/get-cached-path.phpt
+++ b/tests/get-cached-path.phpt
@@ -14,6 +14,8 @@ Patchwork\Config\State::$cachePath = $cachePath;
 
 if ( ! is_dir($cachePath)) {
     mkdir($cachePath);
+} else {
+    echo "The cache directory should not exist in advance.\n";
 }
 
 // The expected path depends on the current implementation of getCachedPath().
@@ -34,6 +36,13 @@ $actualPath = \Patchwork\CodeManipulation\getCachedPath($file);
 echo $actualPath === $expectedPath ? 'PASS' : 'FAIL';
 ?>
 
+--CLEAN--
+<?php
+
+unlink(__DIR__ . '/cache/index.csv');
+rmdir(__DIR__ . '/cache');
+
+?>
 --EXPECT--
 PASS
 PASS

--- a/tests/get-cached-path.phpt
+++ b/tests/get-cached-path.phpt
@@ -12,6 +12,10 @@ $cachePath = str_replace('\\', '/', __DIR__ . '/cache');
 Patchwork\CodeManipulation\State::$cacheIndexFile = null;
 Patchwork\Config\State::$cachePath = $cachePath;
 
+if ( ! is_dir($cachePath)) {
+    mkdir($cachePath);
+}
+
 // Test getCachedPath function
 $file = 'test-file.php';
 $hash = md5($file);

--- a/tests/get-cached-path.phpt
+++ b/tests/get-cached-path.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Test getCachedPath function
+
+--FILE--
+<?php
+
+require __DIR__ . "/../Patchwork.php";
+
+use Patchwork\CodeManipulation\Stream;
+
+$cachePath = str_replace('\\', '/', __DIR__ . '/cache');
+Patchwork\CodeManipulation\State::$cacheIndexFile = null;
+Patchwork\Config\State::$cachePath = $cachePath;
+
+// Test getCachedPath function
+$file = 'test-file.php';
+$hash = md5($file);
+
+$expectedPath = $cachePath . '/' . $hash . '.php';
+
+// First pass - index.csv file does not exist.
+$actualPath = \Patchwork\CodeManipulation\getCachedPath($file);
+
+echo $actualPath === $expectedPath ? 'PASS' : 'FAIL';
+echo "\n";
+
+// Second pass - index.csv file exists.
+$actualPath = \Patchwork\CodeManipulation\getCachedPath($file);
+
+echo $actualPath === $expectedPath ? 'PASS' : 'FAIL';
+?>
+
+--EXPECT--
+PASS
+PASS

--- a/tests/get-cached-path.phpt
+++ b/tests/get-cached-path.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test getCachedPath function
+Test getCachedPath function (https://github.com/antecedent/patchwork/pull/170)
 
 --FILE--
 <?php
@@ -16,7 +16,7 @@ if ( ! is_dir($cachePath)) {
     mkdir($cachePath);
 }
 
-// Test getCachedPath function
+// The expected path depends on the current implementation of getCachedPath().
 $file = 'test-file.php';
 $hash = md5($file);
 


### PR DESCRIPTION
Fixed: "Deprecated: str_getcsv(): the $escape parameter must be provided as its default value will change."