### PR TITLE
getCachedPath(): improve test

### DIFF
--- a/tests/get-cached-path.phpt
+++ b/tests/get-cached-path.phpt
@@ -34,7 +34,27 @@ echo "\n";
 $actualPath = \Patchwork\CodeManipulation\getCachedPath($file);
 
 echo $actualPath === $expectedPath ? 'PASS' : 'FAIL';
+echo "\n";
+
+// Third pass - index.csv file exists, different file being passed.
+// This test would hit a PHP 8.4 deprecation without the fix from PR #170.
+
+// Reset the state to ensure we hit the code which would cause the deprecation
+// notice without the fix from #170.
+Patchwork\CodeManipulation\State::$cacheIndexFile = null;
+Patchwork\Config\State::$cachePath = $cachePath;
+
+$file = 'another-file.php';
+$hash = md5($file);
+
+$expectedPath = $cachePath . '/' . $hash . '.php';
+
+$actualPath = \Patchwork\CodeManipulation\getCachedPath($file);
+
+echo $actualPath === $expectedPath ? 'PASS' : 'FAIL';
+echo "\n";
 ?>
+===DONE===
 
 --CLEAN--
 <?php
@@ -46,3 +66,5 @@ rmdir(__DIR__ . '/cache');
 --EXPECT--
 PASS
 PASS
+PASS
+===DONE===


### PR DESCRIPTION
The test as added in PR #170 did not actually hit the PHP 8.4 deprecation notice, which - while it is a useful test for other reasons - makes it an ineffective test for safeguarding the fix from #170, which was about preventing the PHP 8.4 deprecation notice.

This commit updates the test to ensure the fix for the PHP 8.4 deprecation notice is now properly safeguarded.

This can be verified by undoing the change to the `src/CodeManipulation.php` file from #170 and running this test on PHP 8.4. The test will fail and show the deprecation notice. When the change from #170 is re-applied, the test will pass without the deprecation notice.

Includes adding the `===DONE===` markers for consistency with the other tests.