### PR TITLE
GH Actions: apply work-around for testing against PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: ${{ matrix.php-versions }}
+        php-version: ${{ matrix.php-versions == '8.5' && '8.4' || matrix.php-versions }}
         extensions: mbstring
         ini-values: zend.assertions=1, error_reporting=-1, display_errors=On, display_startup_errors=On, log_errors_max_len=0
         coverage: none
@@ -48,6 +48,15 @@ jobs:
       with:
         composer-options: --ignore-platform-reqs
         custom-cache-suffix: $(date -u "+%Y-%m")
+
+    - name: "Setup PHP again (PHP 8.5)"
+      if: ${{ matrix.php-versions == '8.5' }}
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        extensions: mbstring
+        ini-values: zend.assertions=1, error_reporting=-1, display_errors=On, display_startup_errors=On, log_errors_max_len=0
+        coverage: none
 
     - name: Run tests
       run: vendor/bin/phpunit tests


### PR DESCRIPTION
Currently every single `composer install` on PHP 8.5 fails due to a deprecation notice coming from a Composer dependency during the reading of the `composer.json` file.

While it is expected that this will be fixed soonish (fix is already available in the dependency, we're just waiting for a new release of both the dependency as well as of Composer), I rather not have the red crosses on every single PR while working on getting a new version released.

So, this commit adds a temporary work-around which should allow the tests to run against PHP 8.5 again. This should also allow us to monitor if any of the other deprecation PRs which have gone into PHP 8.5 cause issues for Patchwork.

Once a new version of Composer has been released, we should be able to revert this commit.