### PR TITLE
CS fixes: always use parentheses when instantiating a class

### DIFF
--- a/Patchwork.php
+++ b/Patchwork.php
@@ -36,7 +36,7 @@ function relay(?array $args = null)
 
 function fallBack()
 {
-    throw new Exceptions\NoResult;
+    throw new Exceptions\NoResult();
 }
 
 function restore(CallRerouting\Handle $handle)

--- a/src/CallRerouting.php
+++ b/src/CallRerouting.php
@@ -71,7 +71,7 @@ const INSTANTIATOR_CODE = '
 function connect($source, callable $target, ?Handle $handle = null, $partOfWildcard = false)
 {
     $source = translateIfLanguageConstruct($source);
-    $handle = $handle ?: new Handle;
+    $handle = $handle ?: new Handle();
     list($class, $method) = Utils\interpretCallable($source);
     if (constitutesWildcard($source)) {
         return applyWildcard($source, $target, $handle);
@@ -112,7 +112,7 @@ function constitutesWildcard($source)
 
 function applyWildcard($wildcard, callable $target, ?Handle $handle = null)
 {
-    $handle = $handle ?: new Handle;
+    $handle = $handle ?: new Handle();
     list($class, $method, $instance) = Utils\interpretCallable($wildcard);
     if (!empty($instance)) {
         foreach (Utils\matchWildcard($method, get_class_methods($instance)) as $item) {
@@ -181,7 +181,7 @@ function inPreprocessedFile($callable)
 
 function connectFunction($function, callable $target, ?Handle $handle = null)
 {
-    $handle = $handle ?: new Handle;
+    $handle = $handle ?: new Handle();
     $routes = &State::$routes[''][$function];
     $offset = Utils\append($routes, [$target, $handle]);
     $handle->addReference($routes[$offset]);
@@ -190,7 +190,7 @@ function connectFunction($function, callable $target, ?Handle $handle = null)
 
 function queueConnection($source, callable $target, ?Handle $handle = null)
 {
-    $handle = $handle ?: new Handle;
+    $handle = $handle ?: new Handle();
     $offset = Utils\append(State::$queue, [$source, $target, $handle]);
     $handle->addReference(State::$queue[$offset]);
     return $handle;
@@ -213,7 +213,7 @@ function deployQueue()
 
 function connectMethod($function, callable $target, ?Handle $handle = null)
 {
-    $handle = $handle ?: new Handle;
+    $handle = $handle ?: new Handle();
     list($class, $method, $instance) = Utils\interpretCallable($function);
     $target = new Decorator($target);
     $target->superclass = $class;
@@ -235,9 +235,9 @@ function connectMethod($function, callable $target, ?Handle $handle = null)
 function connectInstantiation($class, callable $target, ?Handle $handle = null)
 {
     if (!Config\isNewKeywordRedefinable()) {
-        throw new Exceptions\NewKeywordNotRedefinable;
+        throw new Exceptions\NewKeywordNotRedefinable();
     }
-    $handle = $handle ?: new Handle;
+    $handle = $handle ?: new Handle();
     $class = strtr($class, ['\\' => '__']);
     $routes = &State::$routes["Patchwork\\Instantiators\\$class"]['instantiate'];
     $offset = Utils\append($routes, [$target, $handle]);
@@ -318,7 +318,7 @@ function relay(?array $args = null)
 
     $route = &State::$routes[$class][$method][$offset];
     $backup = $route;
-    $route = ['Patchwork\fallBack', new Handle];
+    $route = ['Patchwork\fallBack', new Handle()];
     $top = Stack\top();
     if ($args === null) {
         $args = $top['args'];
@@ -600,7 +600,7 @@ function getInstantiator($class, $calledClass)
         });
     }
     $instantiator = "$namespace\\$adaptedName";
-    return new $instantiator;
+    return new $instantiator();
 }
 
 class State

--- a/src/CodeManipulation/Source.php
+++ b/src/CodeManipulation/Source.php
@@ -303,7 +303,7 @@ class Source
         $result = &$this->cache;
         foreach (array_merge([$location], $args) as $step) {
             if (!is_scalar($step)) {
-                throw new \LogicException;
+                throw new \LogicException();
             }
             if (!isset($result[$step])) {
                 $result[$step] = [];

--- a/src/CodeManipulation/Stream.php
+++ b/src/CodeManipulation/Stream.php
@@ -82,7 +82,7 @@ class Stream
     {
         if (isset(static::$otherWrapperClass)) {
             $class = static::$otherWrapperClass;
-            $otherWrapper = new $class;
+            $otherWrapper = new $class();
             if ($context !== null) {
                 $otherWrapper->context = $context;
             }

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -52,7 +52,7 @@ function top($property = null)
 function topOffset()
 {
     if (empty(State::$items)) {
-        throw new Exceptions\StackEmpty;
+        throw new Exceptions\StackEmpty();
     }
     list($offset, $calledClass) = end(State::$items);
     return $offset;
@@ -61,7 +61,7 @@ function topOffset()
 function topCalledClass()
 {
     if (empty(State::$items)) {
-        throw new Exceptions\StackEmpty;
+        throw new Exceptions\StackEmpty();
     }
     list($offset, $calledClass) = end(State::$items);
     return $calledClass;
@@ -70,7 +70,7 @@ function topCalledClass()
 function topArgsOverride()
 {
     if (empty(State::$items)) {
-        throw new Exceptions\StackEmpty;
+        throw new Exceptions\StackEmpty();
     }
     list($offset, $calledClass, $argsOverride) = end(State::$items);
     return $argsOverride;

--- a/tests/includes/InheritanceWithAssertions.php
+++ b/tests/includes/InheritanceWithAssertions.php
@@ -37,7 +37,7 @@ class BazObject extends BarObject
 Patchwork\CallRerouting\deployQueue();
 
 $foo = new FooObject;
-$bar = new BarObject;
+$bar = new BarObject();
 $baz = new BazObject;
 
 assert($foo->getFoo() === "foo");

--- a/tests/includes/RedefinitionOfNewWithUse.php
+++ b/tests/includes/RedefinitionOfNewWithUse.php
@@ -19,7 +19,7 @@ namespace Bar
         return 'test2';
     });
 
-    $test = new TestClass;
+    $test = new TestClass();
 
     assert($test->testMethod() === 'test2');
 }

--- a/tests/includes/Singleton.php
+++ b/tests/includes/Singleton.php
@@ -6,7 +6,7 @@ class Singleton
     {
         static $instance = null;
         if (!isset($instance)) {
-            $instance = new self;
+            $instance = new self();
         }
         return $instance;
     }


### PR DESCRIPTION
Preliminary PR to unblock introducing code style rules as discussed in https://github.com/antecedent/patchwork/pull/180#issuecomment-3302897428 (and follow-up comments).

Includes selectively applying this to a few of the test fixtures to make them more syntax-varied without affecting their function.