### PR TITLE
CS fixes/src: all methods/properties/constants should have a declared visibility

### DIFF
--- a/src/CallRerouting.php
+++ b/src/CallRerouting.php
@@ -605,8 +605,8 @@ function getInstantiator($class, $calledClass)
 
 class State
 {
-    static $routes = [];
-    static $queue = [];
-    static $preprocessedFiles = [];
-    static $routeStack = [];
+    public static $routes = [];
+    public static $queue = [];
+    public static $preprocessedFiles = [];
+    public static $routeStack = [];
 }

--- a/src/CodeManipulation.php
+++ b/src/CodeManipulation.php
@@ -181,8 +181,8 @@ function onImport($listeners)
 
 class State
 {
-    static $actions = [];
-    static $importListeners = [];
-    static $cacheIndex = [];
-    static $cacheIndexFile;
+    public static $actions = [];
+    public static $importListeners = [];
+    public static $cacheIndex = [];
+    public static $cacheIndexFile;
 }

--- a/src/CodeManipulation/Actions/RedefinitionOfNew.php
+++ b/src/CodeManipulation/Actions/RedefinitionOfNew.php
@@ -198,5 +198,5 @@ function suspendFor(callable $function)
 
 class State
 {
-    static $enabled = true;
+    public static $enabled = true;
 }

--- a/src/CodeManipulation/Source.php
+++ b/src/CodeManipulation/Source.php
@@ -14,14 +14,14 @@ use Patchwork\Utils;
 
 class Source
 {
-    const TYPE_OFFSET = 0;
-    const STRING_OFFSET = 1;
+    public const TYPE_OFFSET = 0;
+    public const STRING_OFFSET = 1;
 
-    const PREPEND = 'PREPEND';
-    const APPEND = 'APPEND';
-    const OVERWRITE = 'OVERWRITE';
+    public const PREPEND = 'PREPEND';
+    public const APPEND = 'APPEND';
+    public const OVERWRITE = 'OVERWRITE';
 
-    const ANY = null;
+    public const ANY = null;
 
     public $tokens;
     public $tokensByType;
@@ -37,13 +37,13 @@ class Source
     public $tokensByLevelAndType;
     public $cache;
 
-    function __construct($string)
+    public function __construct($string)
     {
         $this->code = $string;
         $this->initialize();
     }
 
-    function initialize()
+    public function initialize()
     {
         $this->tokens = Utils\tokenize($this->code);
         $this->tokens[] = [T_WHITESPACE, ""];
@@ -55,7 +55,7 @@ class Source
         $this->cache = [];
     }
 
-    function indexTokensByType()
+    public function indexTokensByType()
     {
         $this->tokensByType = [];
         foreach ($this->tokens as $offset => $token) {
@@ -63,7 +63,7 @@ class Source
         }
     }
 
-    function collectBracketMatchings()
+    public function collectBracketMatchings()
     {
         $this->matchingBrackets = [];
         $stack = [];
@@ -89,7 +89,7 @@ class Source
         }
     }
 
-    function collectLevelInfo()
+    public function collectLevelInfo()
     {
         $level = 0;
         $this->levels = [];
@@ -123,7 +123,7 @@ class Source
         Utils\appendUnder($this->levelEndings, 0, count($this->tokens) - 1);
     }
 
-    function has($types)
+    public function has($types)
     {
         foreach ((array) $types as $type) {
             if ($this->all($type) !== []) {
@@ -133,7 +133,7 @@ class Source
         return false;
     }
 
-    function is($types, $offset)
+    public function is($types, $offset)
     {
         foreach ((array) $types as $type) {
             if ($this->tokens[$offset][self::TYPE_OFFSET] === $type) {
@@ -143,7 +143,7 @@ class Source
         return false;
     }
 
-    function skip($types, $offset, $direction = 1)
+    public function skip($types, $offset, $direction = 1)
     {
         $offset += $direction;
         $types = (array) $types;
@@ -156,12 +156,12 @@ class Source
         return ($direction > 0) ? INF : -1;
     }
 
-    function skipBack($types, $offset)
+    public function skipBack($types, $offset)
     {
         return $this->skip($types, $offset, -1);
     }
 
-    function within($types, $low, $high)
+    public function within($types, $low, $high)
     {
         $result = [];
         foreach ((array) $types as $type) {
@@ -171,7 +171,7 @@ class Source
         return $result;
     }
 
-    function read($offset, $count = 1)
+    public function read($offset, $count = 1)
     {
         $result = '';
         $pos = $offset;
@@ -186,7 +186,7 @@ class Source
         return $result;
     }
 
-    function siblings($types, $offset)
+    public function siblings($types, $offset)
     {
         $level = $this->levels[$offset];
         $begin = Utils\lastNotGreaterThan(Utils\access($this->levelBeginnings, $level, []), $offset);
@@ -203,7 +203,7 @@ class Source
         }
     }
 
-    function next($types, $offset)
+    public function next($types, $offset)
     {
         if (!is_array($types)) {
             $candidates = Utils\access($this->tokensByType, $types, []);
@@ -216,7 +216,7 @@ class Source
         return $result;
     }
 
-    function all($types)
+    public function all($types)
     {
         if (!is_array($types)) {
             return Utils\access($this->tokensByType, $types, []);
@@ -229,13 +229,13 @@ class Source
         return $result;
     }
 
-    function match($offset)
+    public function match($offset)
     {
         $offset = (string) $offset;
         return isset($this->matchingBrackets[$offset]) ? $this->matchingBrackets[$offset] : INF;
     }
 
-    function splice($splice, $offset, $length = 0, $policy = self::OVERWRITE)
+    public function splice($splice, $offset, $length = 0, $policy = self::OVERWRITE)
     {
         if ($policy === self::OVERWRITE) {
             $this->splices[$offset] = $splice;
@@ -256,7 +256,7 @@ class Source
         $this->code = null;
     }
 
-    function createCodeFromTokens()
+    public function createCodeFromTokens()
     {
         $splices = $this->splices;
         $code = "";
@@ -274,12 +274,12 @@ class Source
         $this->code = $code;
     }
 
-    static function junk()
+    public static function junk()
     {
         return [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT];
     }
 
-    function __toString()
+    public function __toString()
     {
         if ($this->code === null) {
             $this->createCodeFromTokens();
@@ -287,7 +287,7 @@ class Source
         return (string) $this->code;
     }
 
-    function flush()
+    public function flush()
     {
         $this->initialize(Utils\tokenize($this));
     }
@@ -295,7 +295,7 @@ class Source
     /**
      * @since 2.1.0
      */
-    function cache(array $args, \Closure $function)
+    public function cache(array $args, \Closure $function)
     {
         $found = true;
         $trace = debug_backtrace()[1];

--- a/src/CodeManipulation/Stream.php
+++ b/src/CodeManipulation/Stream.php
@@ -13,9 +13,9 @@ use Patchwork\Utils;
 
 class Stream
 {
-    const STREAM_OPEN_FOR_INCLUDE = 128;
-    const STAT_MTIME_NUMERIC_OFFSET = 9;
-    const STAT_MTIME_ASSOC_OFFSET = 'mtime';
+    public const STREAM_OPEN_FOR_INCLUDE = 128;
+    public const STAT_MTIME_NUMERIC_OFFSET = 9;
+    public const STAT_MTIME_ASSOC_OFFSET = 'mtime';
 
     protected static $protocols = ['file', 'phar'];
     protected static $otherWrapperClass;

--- a/src/Config.php
+++ b/src/Config.php
@@ -224,11 +224,11 @@ function getTimestamp()
 
 class State
 {
-    static $blacklist = [];
-    static $whitelist = [];
-    static $cachePath;
-    static $redefinableInternals = [];
-    static $redefinableLanguageConstructs = [];
-    static $newKeywordRedefinable = false;
-    static $timestamp = 0;
+    public static $blacklist = [];
+    public static $whitelist = [];
+    public static $cachePath;
+    public static $redefinableInternals = [];
+    public static $redefinableLanguageConstructs = [];
+    public static $newKeywordRedefinable = false;
+    public static $timestamp = 0;
 }

--- a/src/Exceptions.php
+++ b/src/Exceptions.php
@@ -26,7 +26,7 @@ class StackEmpty extends Exception
 
 abstract class CallbackException extends Exception
 {
-    function __construct($callback)
+    public function __construct($callback)
     {
         parent::__construct(sprintf($this->message, Utils\callableToString($callback)));
     }
@@ -39,7 +39,7 @@ class NotUserDefined extends CallbackException
 
 class DefinedTooEarly extends CallbackException
 {
-    function __construct($callback)
+    public function __construct($callback)
     {
         $this->message = "The file that defines %s() was included earlier than Patchwork. " .
                          "Please reverse this order to be able to redefine the function in question.";
@@ -62,7 +62,7 @@ class InternalsNotSupportedOnHHVM extends CallbackException
 
 class CachePathUnavailable extends Exception
 {
-    function __construct($location)
+    public function __construct($location)
     {
         parent::__construct(sprintf(
             "The specified cache path is nonexistent or read-only: %s",
@@ -77,7 +77,7 @@ class ConfigException extends Exception
 
 class ConfigMalformed extends ConfigException
 {
-    function __construct($file, $message)
+    public function __construct($file, $message)
     {
         parent::__construct(sprintf(
             'The configuration file %s is malformed: %s',
@@ -89,7 +89,7 @@ class ConfigMalformed extends ConfigException
 
 class ConfigKeyNotRecognized extends ConfigException
 {
-    function __construct($key, $list, $file)
+    public function __construct($key, $list, $file)
     {
         parent::__construct(sprintf(
             "The key '%s' in the configuration file %s was not recognized. " .
@@ -103,7 +103,7 @@ class ConfigKeyNotRecognized extends ConfigException
 
 class CachePathConflict extends ConfigException
 {
-    function __construct($first, $second)
+    public function __construct($first, $second)
     {
         parent::__construct(sprintf(
             "Detected configuration files provide conflicting cache paths: %s and %s",

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -92,5 +92,5 @@ function allCalledClasses()
 
 class State
 {
-    static $items = [];
+    public static $items = [];
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -385,5 +385,5 @@ function tokenize($string)
 
 class State
 {
-    static $missedCallables = [];
+    public static $missedCallables = [];
 }


### PR DESCRIPTION
Preliminary PR to unblock introducing code style rules as discussed in https://github.com/antecedent/patchwork/pull/180#issuecomment-3302897428 (and follow-up comments).

To not break BC, all methods/properties/constants without declared visibility have now been declared as `public`.