### PR TITLE
Treat constructors as implicitly void-typed for the purposes of `prependCodeToFunctions()`

### DIFF
--- a/src/CodeManipulation/Actions/Generic.php
+++ b/src/CodeManipulation/Actions/Generic.php
@@ -78,6 +78,10 @@ function prependCodeToFunctions($code, $typedVariants = array(), $fillArgRefs = 
 function getDeclaredReturnType(Source $s, $function)
 {
     $parenthesis = $s->next(LEFT_ROUND, $function);
+    $name = $s->next(T_STRING, $function);
+    if ($name < $parenthesis && $s->read($name) === '__construct') {
+        return 'void';
+    }
     $next = $s->skip(Source::junk(), $s->match($parenthesis));
     if ($s->is(T_USE, $next)) {
         $next = $s->skip(Source::junk(), $s->match($s->next(LEFT_ROUND, $next)));

--- a/src/CodeManipulation/Actions/Generic.php
+++ b/src/CodeManipulation/Actions/Generic.php
@@ -79,7 +79,7 @@ function getDeclaredReturnType(Source $s, $function)
 {
     $parenthesis = $s->next(LEFT_ROUND, $function);
     $name = $s->next(T_STRING, $function);
-    if ($name < $parenthesis && $s->read($name) === '__construct') {
+    if ($name < $parenthesis && ($s->read($name) === '__construct' || $s->read($name) === '__destruct')) {
         return 'void';
     }
     $next = $s->skip(Source::junk(), $s->match($parenthesis));

--- a/tests/includes/NamedObject.php
+++ b/tests/includes/NamedObject.php
@@ -17,4 +17,17 @@ class NamedObject
     public function __destruct()
     {
     }
+
+    public static function createAnonymousSubclassInstance()
+    {
+        return new class extends NamedObject {
+            public function __construct()
+            {
+            }
+
+            public function __destruct()
+            {
+            }
+        };
+    }
 }

--- a/tests/includes/NamedObject.php
+++ b/tests/includes/NamedObject.php
@@ -31,3 +31,5 @@ class NamedObject
         };
     }
 }
+
+NamedObject::createAnonymousSubclassInstance();

--- a/tests/includes/NamedObject.php
+++ b/tests/includes/NamedObject.php
@@ -4,13 +4,17 @@ class NamedObject
 {
     private $name;
 
-    function __construct($name)
+    public function __construct($name)
     {
         $this->name = $name;
     }
 
-    function getName()
+    public function getName()
     {
         return $this->name;
+    }
+
+    public function __destruct()
+    {
     }
 }

--- a/tests/return-from-constructor.phpt
+++ b/tests/return-from-constructor.phpt
@@ -38,10 +38,9 @@ try {
     echo get_class($e), "\n";
 }
 
-echo "(has its own constructor that is not redefinable using Patchwork)\n";
-
-assert($classes === ['NamedObject']);
-
+assert(count($classes) === 2);
+assert($classes[0] === 'NamedObject');
+assert($classes[1] !== 'NamedObject');
 ?>
 ===DONE===
 
@@ -49,5 +48,5 @@ assert($classes === ['NamedObject']);
 Named class:
 Patchwork\Exceptions\NonNullToVoid
 Anonymous subclass:
-(has its own constructor that is not redefinable using Patchwork)
+Patchwork\Exceptions\NonNullToVoid
 ===DONE===

--- a/tests/return-from-constructor.phpt
+++ b/tests/return-from-constructor.phpt
@@ -14,8 +14,14 @@ $_SERVER['PHP_SELF'] = __FILE__;
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/NamedObject.php";
 
-redefine('NamedObject::__construct', function ($name) {
-   return $name; 
+$classes = [];
+
+echo "Named class:\n";
+
+redefine('*::__construct', function () use (&$classes) {
+    $class = get_class($this);
+    $classes[] = $class;
+    return $class;
 });
 
 try {
@@ -24,9 +30,24 @@ try {
     echo get_class($e), "\n";
 }
 
+echo "Anonymous subclass:\n";
+
+try {
+    NamedObject::createAnonymousSubclassInstance();
+} catch (Exception $e) {
+    echo get_class($e), "\n";
+}
+
+echo "(has its own constructor that is not redefinable using Patchwork)\n";
+
+assert($classes === ['NamedObject']);
+
 ?>
 ===DONE===
 
 --EXPECT--
+Named class:
 Patchwork\Exceptions\NonNullToVoid
+Anonymous subclass:
+(has its own constructor that is not redefinable using Patchwork)
 ===DONE===

--- a/tests/return-from-constructor.phpt
+++ b/tests/return-from-constructor.phpt
@@ -1,0 +1,32 @@
+--TEST--
+https://github.com/antecedent/patchwork/issues/213
+
+--FILE--
+<?php
+
+use function Patchwork\redefine;
+
+ini_set('zend.assertions', 1);
+error_reporting(E_ALL);
+
+$_SERVER['PHP_SELF'] = __FILE__;
+
+require __DIR__ . "/../Patchwork.php";
+require __DIR__ . "/includes/NamedObject.php";
+
+redefine('NamedObject::__construct', function ($name) {
+   return $name; 
+});
+
+try {
+    new NamedObject('foo');
+} catch (Exception $e) {
+    echo get_class($e), "\n";
+}
+
+?>
+===DONE===
+
+--EXPECT--
+Patchwork\Exceptions\NonNullToVoid
+===DONE===

--- a/tests/return-from-destructor.phpt
+++ b/tests/return-from-destructor.phpt
@@ -14,9 +14,15 @@ $_SERVER['PHP_SELF'] = __FILE__;
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/NamedObject.php";
 
-redefine('NamedObject::__destruct', function () {
-   return __CLASS__; 
+$classes = [];
+
+redefine('*::__destruct', function () use (&$classes) {
+    $class = get_class($this);
+    $classes[] = $class;
+    return $class;
 });
+
+echo "Named class:\n";
 
 try {
     new NamedObject('foo');
@@ -24,9 +30,24 @@ try {
     echo get_class($e), "\n";
 }
 
+echo "Anonymous subclass:\n";
+
+try {
+    NamedObject::createAnonymousSubclassInstance();
+} catch (Exception $e) {
+    echo get_class($e), "\n";
+}
+
+echo "(has its own destructor that is not redefinable using Patchwork)\n";
+
+assert($classes === ['NamedObject']);
+
 ?>
 ===DONE===
 
 --EXPECT--
+Named class:
 Patchwork\Exceptions\NonNullToVoid
+Anonymous subclass:
+(has its own destructor that is not redefinable using Patchwork)
 ===DONE===

--- a/tests/return-from-destructor.phpt
+++ b/tests/return-from-destructor.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Return from constructor / antecedent/patchwork#213
+Return from destructor / antecedent/patchwork#213
 
 --FILE--
 <?php
@@ -14,8 +14,8 @@ $_SERVER['PHP_SELF'] = __FILE__;
 require __DIR__ . "/../Patchwork.php";
 require __DIR__ . "/includes/NamedObject.php";
 
-redefine('NamedObject::__construct', function ($name) {
-   return $name; 
+redefine('NamedObject::__destruct', function () {
+   return __CLASS__; 
 });
 
 try {

--- a/tests/return-from-destructor.phpt
+++ b/tests/return-from-destructor.phpt
@@ -38,9 +38,9 @@ try {
     echo get_class($e), "\n";
 }
 
-echo "(has its own destructor that is not redefinable using Patchwork)\n";
-
-assert($classes === ['NamedObject']);
+assert(count($classes) === 2);
+assert($classes[0] === 'NamedObject');
+assert($classes[1] !== 'NamedObject');
 
 ?>
 ===DONE===
@@ -49,5 +49,5 @@ assert($classes === ['NamedObject']);
 Named class:
 Patchwork\Exceptions\NonNullToVoid
 Anonymous subclass:
-(has its own destructor that is not redefinable using Patchwork)
+Patchwork\Exceptions\NonNullToVoid
 ===DONE===


### PR DESCRIPTION
See #213.

The title assumes `use function Patchwork\CodeManipulation\Actions\Generic\prependCodeToFunctions`.
