### PR TITLE
PHP 8.6 | Tests: handle change in error message format 

### DIFF
--- a/tests/require-missing-php5.phpt
+++ b/tests/require-missing-php5.phpt
@@ -1,12 +1,12 @@
 --TEST--
-Include and require of nonexistent files
+Include and require of nonexistent files (PHP < 8.0)
 
 --SKIPIF--
 <?php
 // PHP 8.0 changed require failing from a fatal error to a thrown exception. That's too much of a difference
 // to handle easily in EXPECTF, easier to just copy the file.
-if (!version_compare(PHP_VERSION, "8.0", "<")) {
-    echo "skip PHP 5 version of the test in PHP 8+";
+if (version_compare(PHP_VERSION_ID, "80000", ">=")) {
+    echo "skip PHP 7 version of the test on PHP 8+";
 }
 --FILE--
 <?php

--- a/tests/require-missing-phpgte86.phpt
+++ b/tests/require-missing-phpgte86.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Include and require of nonexistent files (PHP >= 8.6)
+
+--SKIPIF--
+<?php
+// PHP 8.6 changed the error message format significantly. That's too much of a difference
+// to handle easily in EXPECTF, easier to just copy the file.
+if (version_compare(PHP_VERSION_ID, "80600", "<")) {
+    echo "skip PHP 8.6+ version of the test on PHP <8.6";
+}
+--FILE--
+<?php
+
+ini_set('zend.assertions', 1);
+error_reporting(E_ALL);
+
+require __DIR__ . "/../Patchwork.php";
+
+echo "Including missing file...\n";
+include __DIR__ . "/includes/does-not-exist.php";
+echo "Good, it did not throw/exit.\n\n";
+
+echo "Requiring missing file...\n";
+require __DIR__ . "/includes/does-not-exist.php";
+echo "It did not throw/exit. This is wrong.\n";
+
+?>
+===DONE===
+
+--EXPECTF--
+Including missing file...
+
+Warning: fopen('%s', 'r', true): Failed to open stream: No such file or directory in %s%esrc%eCodeManipulation%eStream.php on line %d
+
+Warning: include('%s'): Failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in %s on line 9
+
+Warning: include('%s'): Failed opening '%s/includes/does-not-exist.php' for inclusion (include_path='%s') in %s on line 9
+Good, it did not throw/exit.
+
+Requiring missing file...
+
+Warning: fopen('%s', 'r', true): Failed to open stream: No such file or directory in %s%esrc%eCodeManipulation%eStream.php on line %d
+
+Warning: require('%s'): Failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in %s on line 13
+
+Fatal error: Uncaught Error: Failed opening required '%s/includes/does-not-exist.php' (include_path='%s') in %s:13
+Stack trace:
+#0 {main}
+  thrown in %s on line 13

--- a/tests/require-missing.phpt
+++ b/tests/require-missing.phpt
@@ -1,12 +1,12 @@
 --TEST--
-Include and require of nonexistent files
+Include and require of nonexistent files (PHP 8.0-8.5)
 
 --SKIPIF--
 <?php
 // PHP 8.0 changed require failing from a fatal error to a thrown exception. That's too much of a difference
 // to handle easily in EXPECTF, easier to just copy the file.
-if (!version_compare(PHP_VERSION, "8.0", ">=")) {
-    echo "skip PHP 8+ version of the test in PHP <8";
+if (version_compare(PHP_VERSION_ID, "80000", "<")) {
+    echo "skip PHP 8.0-8.5 version of the test on PHP <8";
 }
 --FILE--
 <?php

--- a/tests/require-missing.phpt
+++ b/tests/require-missing.phpt
@@ -8,6 +8,9 @@ Include and require of nonexistent files (PHP 8.0-8.5)
 if (version_compare(PHP_VERSION_ID, "80000", "<")) {
     echo "skip PHP 8.0-8.5 version of the test on PHP <8";
 }
+if (version_compare(PHP_VERSION_ID, "80600", ">=")) {
+    echo "skip PHP 8.0-8.5 version of the test on PHP >=8.6";
+}
 --FILE--
 <?php
 


### PR DESCRIPTION
### Tests/require-missing: clarify skip conditions 

* As support for PHP < 7.1 has been dropped, we can use `PHP_VERSION_ID` instead of `PHP_VERSION` for the version comparisons.
* Using a positive condition instead of a negative one improves the readability of the test code.
* Ensure the tests have unique names.

### PHP 8.6 | Tests: handle change in error message format 

This update the `require-missing*.phpt` tests by adding a new test file to handle the PHP 8.6+ format of the expected error messages.

Ref: https://wiki.php.net/rfc/display_error_function_args